### PR TITLE
Setup consumer

### DIFF
--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -1,0 +1,55 @@
+defmodule Mississippi.Consumer do
+  @moduledoc """
+  This module defines the supervision tree of Mississippi.Consumer.
+  """
+  use Supervisor
+
+  @type ssl_option ::
+          {:cacertfile, String.t()}
+          | {:verify, :verify_peer}
+          | {:server_name_indication, charlist() | :disable}
+          | {:depth, integer()}
+  @type ssl_options :: :none | [ssl_option]
+
+  @type amqp_options ::
+          {:username, String.t()}
+          | {:password, String.t()}
+          | {:virtual_host, String.t()}
+          | {:host, String.t()}
+          | {:port, integer()}
+          | {:ssl_options, ssl_options}
+          | {:channels, integer()}
+
+  @type mississippi_queues_config ::
+          {:events_exchange_name, String.t()}
+          | {:data_queue_range_start, non_neg_integer()}
+          | {:data_queue_range_end, pos_integer()}
+          | {:data_queue_total_count, pos_integer()}
+          | {:data_queue_prefix, String.t()}
+
+  @type init_options :: [
+          {:amqp_consumer_options, amqp_options()}
+          | {:mississippi_queues_config, mississippi_queues_config()}
+          | {:events_consumer_connection_number, pos_integer()}
+          | {:message_handler, module()}
+        ]
+
+  @spec start_link(init_options()) :: Supervisor.on_start()
+  def start_link(init_arg) do
+    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(init_arg) do
+    # TODO: `events_consumer_connection_number` should be automatically computed based on
+    # `data_queue_range_start` and `data_queue_range_end` + `channels_per_connections` (this one will arrive soon).
+    children = [
+      {Mississippi.Consumer.DataPipelineSupervisor, init_arg}
+    ]
+
+    # See https://hexdocs.pm/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: Mississippi.Consumer.Supervisor]
+    Supervisor.init(children, opts)
+  end
+end

--- a/lib/consumer/amqp_data_consumer.ex
+++ b/lib/consumer/amqp_data_consumer.ex
@@ -1,0 +1,290 @@
+defmodule Mississippi.Consumer.AMQPDataConsumer do
+  defmodule State do
+    defstruct [
+      :channel,
+      :monitor,
+      :queue_name,
+      :queue_range,
+      :queue_total_count,
+      :message_handler
+    ]
+  end
+
+  require Logger
+  use GenServer
+
+  alias AMQP.Channel
+  alias Mississippi.Consumer.DataUpdater
+
+  # TODO should this be customizable?
+  @reconnect_interval 1_000
+  @adapter ExRabbitPool.RabbitMQ
+  @sharding_key "sharding_key"
+  @consumer_prefetch_count 300
+
+  # API
+
+  def start_link(args) do
+    index = Keyword.fetch!(args, :queue_index)
+    GenServer.start_link(__MODULE__, args, name: get_queue_via_tuple(index))
+  end
+
+  def ack(pid, delivery_tag) do
+    Logger.debug("Going to ack #{inspect(delivery_tag)}")
+    GenServer.call(pid, {:ack, delivery_tag})
+  end
+
+  def discard(pid, delivery_tag) do
+    Logger.debug("Going to discard #{inspect(delivery_tag)}")
+    GenServer.call(pid, {:discard, delivery_tag})
+  end
+
+  def requeue(pid, delivery_tag) do
+    Logger.debug("Going to requeue #{inspect(delivery_tag)}")
+    GenServer.call(pid, {:requeue, delivery_tag})
+  end
+
+  def start_message_tracker(sharding_key) do
+    with {:ok, via_tuple} <- fetch_queue_via_tuple(sharding_key) do
+      GenServer.call(via_tuple, {:start_message_tracker, sharding_key})
+    end
+  end
+
+  def start_data_updater(sharding_key, message_tracker) do
+    with {:ok, via_tuple} <- fetch_queue_via_tuple(sharding_key) do
+      GenServer.call(via_tuple, {:start_data_updater, sharding_key, message_tracker})
+    end
+  end
+
+  defp get_queue_via_tuple(queue_index) when is_integer(queue_index) do
+    {:via, Registry, {Registry.AMQPDataConsumer, {:queue_index, queue_index}}}
+  end
+
+  defp fetch_queue_via_tuple(sharding_key) do
+    GenServer.call(self(), {:fetch_queue_via_tuple, sharding_key})
+  end
+
+  # Server callbacks
+
+  @impl true
+  def init(args) do
+    queue_name = Keyword.fetch!(args, :queue_name)
+    queue_range_start = Keyword.fetch!(args, :data_queue_range_start)
+    queue_range_end = Keyword.fetch!(args, :data_queue_range_end)
+    queue_total_count = Keyword.fetch!(args, :data_queue_total_count)
+    message_handler = Keyword.fetch!(args, :message_handler)
+
+    state = %State{
+      queue_name: queue_name,
+      queue_range: queue_range_start..queue_range_end,
+      queue_total_count: queue_count,
+      message_handler: message_handler
+    }
+
+    {:ok, state, {:continue, :init_consume}}
+  end
+
+  @impl true
+  def handle_continue(:init_consume, state), do: init_consume(state)
+
+  @impl true
+  def handle_call({:ack, delivery_tag}, _from, %State{channel: chan} = state) do
+    res = @adapter.ack(chan, delivery_tag)
+    {:reply, res, state}
+  end
+
+  def handle_call({:discard, delivery_tag}, _from, %State{channel: chan} = state) do
+    res = @adapter.reject(chan, delivery_tag, requeue: false)
+    {:reply, res, state}
+  end
+
+  def handle_call({:requeue, delivery_tag}, _from, %State{channel: chan} = state) do
+    res = @adapter.reject(chan, delivery_tag, requeue: true)
+    {:reply, res, state}
+  end
+
+  def handle_call({:start_message_tracker, realm, device_id}, _from, state) do
+    res = DataUpdater.get_message_tracker(realm, device_id)
+    {:reply, res, state}
+  end
+
+  def handle_call({:start_data_updater, realm, device_id, message_tracker}, _from, state) do
+    %State{message_handler: message_handler} = state
+    res = DataUpdater.get_data_updater_process(realm, device_id, message_tracker, message_handler)
+    {:reply, res, state}
+  end
+
+  def handle_call({:fetch_queue_via_tuple, sharding_key}, _from, state) do
+    %State{
+      queue_total_count: queue_count,
+      queue_range: queue_range
+    } = state
+
+    # TODO refactor: bring out the algorithm
+    # This is the same sharding algorithm used in producer
+    # Make sure they stay in sync
+    queue_index = :erlang.phash2(sharding_key, queue_total_count)
+
+    if queue_index in queue_range do
+      {:reply, {:ok, get_queue_via_tuple(queue_index)}, state}
+    else
+      {:reply, {:error, :unhandled_device}, state}
+    end
+  end
+
+  @impl true
+  def handle_info(:init_consume, state), do: init_consume(state)
+
+  def handle_info(
+        {:DOWN, _, :process, pid, :normal},
+        %State{channel: %Channel{pid: chan_pid}} = state
+      )
+      when pid != chan_pid do
+    # This is a Message Tracker deactivating itself normally, do nothing
+    {:noreply, state}
+  end
+
+  # Make sure to handle monitored message trackers exit messages
+  # Under the hood DataUpdater calls Process.monitor so those monitor are leaked into this process.
+  def handle_info(
+        {:DOWN, monitor, :process, chan_pid, reason},
+        %{monitor: monitor, channel: %{pid: chan_pid}} = state
+      ) do
+    # Channel went down, stop the process
+    Logger.warning("AMQP data consumer crashed, reason: #{inspect(reason)}",
+      tag: "data_consumer_chan_crash"
+    )
+
+    init_consume(%State{state | channel: nil, monitor: nil})
+  end
+
+  # Confirmation sent by the broker after registering this process as a consumer
+  def handle_info({:basic_consume_ok, %{consumer_tag: _consumer_tag}}, state) do
+    {:noreply, state}
+  end
+
+  # Sent by the broker when the consumer is unexpectedly cancelled (such as after a queue deletion)
+  def handle_info({:basic_cancel, %{consumer_tag: _consumer_tag}}, state) do
+    {:noreply, state}
+  end
+
+  # Confirmation sent by the broker to the consumer process after a Basic.cancel
+  def handle_info({:basic_cancel_ok, %{consumer_tag: _consumer_tag}}, state) do
+    {:noreply, state}
+  end
+
+  # Message consumed
+  def handle_info({:basic_deliver, payload, meta}, state) do
+    %State{channel: chan, message_handler: message_handler} = state
+    {headers, no_headers_meta} = Map.pop(meta, :headers, [])
+    headers_map = amqp_headers_to_map(headers)
+
+    {timestamp, clean_meta} = Map.pop(no_headers_meta, :timestamp)
+
+    case handle_consume(payload, headers_map, timestamp, clean_meta, message_handler) do
+      :ok ->
+        :ok
+
+      :invalid_msg ->
+        # ACK invalid msg to discard them
+        @adapter.ack(chan, meta.delivery_tag)
+    end
+
+    {:noreply, state}
+  end
+
+  defp schedule_connect() do
+    Process.send_after(self(), :init_consume, @reconnect_interval)
+  end
+
+  defp init_consume(state) do
+    conn = ExRabbitPool.get_connection_worker(:events_consumer_pool)
+
+    case ExRabbitPool.checkout_channel(conn) do
+      {:ok, channel} ->
+        try_to_setup_consume(channel, conn, state)
+
+      {:error, reason} ->
+        _ =
+          Logger.warning(
+            "Failed to check out channel for consumer on queue #{state.queue_name}: #{inspect(reason)}",
+            tag: "channel_checkout_fail"
+          )
+
+        schedule_connect()
+        {:noreply, state}
+    end
+  end
+
+  defp try_to_setup_consume(channel, conn, state) do
+    %Channel{pid: channel_pid} = channel
+    %State{queue_name: queue_name} = state
+
+    with :ok <- @adapter.qos(channel, prefetch_count: @consumer_prefetch_count),
+         {:ok, _queue} <- @adapter.declare_queue(channel, queue_name, durable: true),
+         {:ok, _consumer_tag} <- @adapter.consume(channel, queue_name, self()) do
+      ref = Process.monitor(channel_pid)
+
+      _ =
+        Logger.debug("AMQPDataConsumer for queue #{queue_name} initialized",
+          tag: "data_consumer_init_ok"
+        )
+
+      {:noreply, %State{state | channel: channel, monitor: ref}}
+    else
+      {:error, reason} ->
+        Logger.warning(
+          "Error initializing AMQPDataConsumer on queue #{state.queue_name}: #{inspect(reason)}",
+          tag: "data_consumer_init_err"
+        )
+
+        # Something went wrong, let's put the channel back where it belongs
+        _ = ExRabbitPool.checkin_channel(conn, channel)
+        schedule_connect()
+        {:noreply, %{state | channel: nil, monitor: nil}}
+    end
+  end
+
+  defp handle_consume(payload, headers, timestamp, meta, message_handler) do
+    with %{@sharding_key => sharding_key} <- headers,
+         {:ok, tracking_id} <- get_tracking_id(meta) do
+      # This call might spawn processes and implicitly monitor them
+      DataUpdater.handle_message(
+        sharding_key,
+        payload,
+        headers,
+        tracking_id,
+        timestamp,
+        message_handler
+      )
+    else
+      _ -> handle_invalid_msg(payload, headers, timestamp, meta)
+    end
+  end
+
+  defp handle_invalid_msg(payload, headers, timestamp, meta) do
+    Logger.warning(
+      "Invalid AMQP message: #{inspect(Base.encode64(payload))} #{inspect(headers)} #{inspect(timestamp)} #{inspect(meta)}",
+      tag: "data_consumer_invalid_msg"
+    )
+
+    :invalid_msg
+  end
+
+  defp amqp_headers_to_map(headers) do
+    Enum.reduce(headers, %{}, fn {key, _type, value}, acc ->
+      Map.put(acc, key, value)
+    end)
+  end
+
+  defp get_tracking_id(meta) do
+    message_id = meta.message_id
+    delivery_tag = meta.delivery_tag
+
+    if is_binary(message_id) and is_integer(delivery_tag) do
+      {:ok, {meta.message_id, meta.delivery_tag}}
+    else
+      {:error, :invalid_message_metadata}
+    end
+  end
+end

--- a/lib/consumer/amqp_data_consumer_supervisor.ex
+++ b/lib/consumer/amqp_data_consumer_supervisor.ex
@@ -1,0 +1,44 @@
+defmodule Mississippi.Consumer.AMQPDataConsumer.Supervisor do
+  use Supervisor
+
+  alias Mississippi.Consumer.AMQPDataConsumer
+
+  def start_link(init_arg) do
+    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(init_arg) do
+    data_queues_config = Keyword.fetch!(init_arg, :mississippi_queues_config)
+    message_handler = Keyword.fetch!(init_arg, :message_handler)
+
+    children =
+      amqp_data_consumers_childspecs(data_queues_config, message_handler)
+
+    opts = [strategy: :one_for_one, name: __MODULE__]
+
+    Supervisor.init(children, opts)
+  end
+
+  defp amqp_data_consumers_childspecs(data_queues_config, message_handler) do
+    queue_range_start = Keyword.fetch!(data_queues_config, :data_queue_range_start)
+    queue_range_end = Keyword.fetch!(data_queues_config, :data_queue_range_end)
+    queue_prefix = Keyword.fetch!(data_queues_config, :data_queue_prefix)
+    queue_total_count = Keyword.fetch!(data_queues_config, :data_queue_total_count)
+
+    for queue_index <- queue_range_start..queue_range_end do
+      queue_name = "#{queue_prefix}#{queue_index}"
+
+      init_args = [
+        queue_name: queue_name,
+        queue_index: queue_index,
+        data_queue_range_start: queue_range_start,
+        data_queue_range_end: queue_range_end,
+        data_queue_total_count: queue_total_count,
+        message_handler: message_handler
+      ]
+
+      Supervisor.child_spec({AMQPDataConsumer, init_args}, id: {AMQPDataConsumer, queue_index})
+    end
+  end
+end

--- a/lib/consumer/consumers_supervisor.ex
+++ b/lib/consumer/consumers_supervisor.ex
@@ -1,0 +1,26 @@
+defmodule Mississippi.Consumer.ConsumersSupervisor do
+  use Supervisor
+  require Logger
+
+  def start_link(init_arg) do
+    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(init_arg) do
+    events_producer_config = Keyword.fetch!(init_arg, :mississippi_queues_config)
+    message_handler = Keyword.fetch!(init_arg, :message_handler)
+
+    Logger.info("AMQPDataConsumer supervisor init.", tag: "data_consumer_sup_init")
+
+    children = [
+      {Registry, [keys: :unique, name: Registry.AMQPDataConsumer]},
+      {Mississippi.Consumer.AMQPDataConsumer.Supervisor,
+       mississippi_queues_config: events_producer_config, message_handler: message_handler}
+    ]
+
+    opts = [strategy: :rest_for_one, name: __MODULE__]
+
+    Supervisor.init(children, opts)
+  end
+end

--- a/lib/consumer/data_pipeline_supervisor.ex
+++ b/lib/consumer/data_pipeline_supervisor.ex
@@ -1,0 +1,43 @@
+defmodule Mississippi.Consumer.DataPipelineSupervisor do
+  use Supervisor
+
+  alias Mississippi.Consumer.ConsumersSupervisor
+
+  def start_link(init_arg) do
+    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(init_arg) do
+    amqp_consumer_options = Keyword.fetch!(init_arg, :amqp_consumer_options)
+
+    events_consumer_connection_number =
+      Keyword.fetch!(init_arg, :events_consumer_connection_number)
+
+    events_producer_config = Keyword.fetch!(init_arg, :mississippi_queues_config)
+
+    message_handler =
+      Keyword.get(init_arg, :message_handler, Mississippi.Consumer.DataUpdater.Handler.Impl)
+
+    children = [
+      {Registry, [keys: :unique, name: Registry.MessageTracker]},
+      {Registry, [keys: :unique, name: Registry.DataUpdater]},
+      {ExRabbitPool.PoolSupervisor,
+       rabbitmq_config: amqp_consumer_options,
+       connection_pools: [events_consumer_pool_config(events_consumer_connection_number)]},
+      {ConsumersSupervisor,
+       mississippi_queues_config: events_producer_config, message_handler: message_handler}
+    ]
+
+    Supervisor.init(children, strategy: :rest_for_one)
+  end
+
+  defp events_consumer_pool_config(events_consumer_connection_number) do
+    [
+      name: {:local, :events_consumer_pool},
+      worker_module: ExRabbitPool.Worker.RabbitConnection,
+      size: events_consumer_connection_number,
+      max_overflow: 0
+    ]
+  end
+end

--- a/lib/consumer/data_updater.ex
+++ b/lib/consumer/data_updater.ex
@@ -1,0 +1,161 @@
+defmodule Mississippi.Consumer.DataUpdater do
+  defmodule State do
+    defstruct [
+      :sharding_key,
+      :message_tracker,
+      :message_handler
+    ]
+  end
+
+  use GenServer
+
+  alias Mississippi.Consumer.AMQPDataConsumer
+  alias Mississippi.Consumer.MessageTracker
+  require Logger
+
+  # TODO make this configurable?
+  @data_updater_deactivation_interval_ms 10_000
+
+  @doc """
+  Start handling a message. If it is the first in-order message, it will be processed
+  straight away by the `message_handler` (which is a module implementing DataUpdater.Handler behaviour).
+  If not, the message will remain in memory until it can be processed, i.e. it is now the first
+  in-order message.
+  """
+  def handle_message(sharding_key, payload, headers, tracking_id, timestamp, message_handler) do
+    message_tracker = get_message_tracker(sharding_key)
+    {message_id, delivery_tag} = tracking_id
+    MessageTracker.track_delivery(message_tracker, message_id, delivery_tag)
+
+    get_data_updater_process(sharding_key, message_tracker, message_handler)
+    |> GenServer.cast({:handle_message, payload, headers, message_id, timestamp})
+  end
+
+  @doc """
+  Provides a reference to the DataUpdater process that will handle the set of messages identified by
+  the given sharding key. Messages going through the DataUpdater process will be tracked by the
+  `message_tracker` and the `message_handler` will be used to process them.
+  """
+  def get_data_updater_process(sharding_key, message_tracker, message_handler, opts \\ []) do
+    case Registry.lookup(Registry.DataUpdater, sharding_key) do
+      [] ->
+        if Keyword.get(opts, :offload_start) do
+          # We pass through AMQPDataConsumer to start the process to make sure that
+          # that start is serialized
+          AMQPDataConsumer.start_data_updater(sharding_key, message_tracker)
+        else
+          name = {:via, Registry, {Registry.DataUpdater, sharding_key}}
+          {:ok, pid} = start(sharding_key, message_tracker, message_handler, name: name)
+          pid
+        end
+
+      [{pid, nil}] ->
+        pid
+    end
+  end
+
+  @doc """
+  Provides a reference to the MessageTracker process that will track the set of messages identified by
+  the given sharding key. The MessageTracker process is linked to the one calling this function.
+  """
+  def get_message_tracker(sharding_key, opts \\ []) do
+    case Registry.lookup(Registry.MessageTracker, sharding_key) do
+      [] ->
+        if Keyword.get(opts, :offload_start) do
+          # We pass through AMQPDataConsumer to start the process to make sure that
+          # that start is serialized and acknowledger is the right process
+          AMQPDataConsumer.start_message_tracker(sharding_key)
+        else
+          acknowledger = self()
+          spawn_message_tracker(acknowledger, sharding_key)
+        end
+
+      [{pid, nil}] ->
+        pid
+    end
+  end
+
+  @doc """
+  Starts a DataUpdater process that will handle the set of messages identified by
+  `sharding_key`. Messages going through the DataUpdater process will be tracked by the
+  `message_tracker` and the `message_handler` will be used to process them.
+  """
+  def start(sharding_key, message_tracker, message_handler, opts \\ []) do
+    init_arg = [
+      sharding_key: sharding_key,
+      message_tracker: message_tracker,
+      message_handler: message_handler
+    ]
+
+    GenServer.start(__MODULE__, init_arg, opts)
+  end
+
+  @impl true
+  def init(init_arg) do
+    sharding_key = Keyword.fetch!(init_arg, :sharding_key)
+    message_tracker = Keyword.fetch!(init_arg, :message_tracker)
+    message_handler = Keyword.fetch!(init_arg, :message_handler)
+
+    MessageTracker.register_data_updater(message_tracker)
+    Process.monitor(message_tracker)
+
+    state = %State{
+      sharding_key: sharding_key,
+      message_tracker: message_tracker,
+      message_handler: message_handler
+    }
+
+    {:ok, state, @data_updater_deactivation_interval_ms}
+  end
+
+  @impl true
+  def handle_cast({:handle_message, payload, headers, message_id, timestamp}, state) do
+    if MessageTracker.can_process_message(state.message_tracker, message_id) do
+      case state.message_handler.handle_message(payload, headers, message_id, timestamp) do
+        {:ok, _} ->
+          _ = Logger.debug("Successfully handled message #{inspect(message_id)}")
+          MessageTracker.ack_delivery(state.message_tracker, message_id)
+
+        {:error, reason} ->
+          _ =
+            Logger.warning(
+              "Error handling message #{inspect(message_id)}, reason #{inspect(reason)}"
+            )
+
+          MessageTracker.discard(state.message_tracker, message_id)
+      end
+    end
+
+    {:noreply, state, @data_updater_deactivation_interval_ms}
+  end
+
+  @impl true
+  def handle_info({:DOWN, _, :process, pid, :normal}, %{message_tracker: pid} = state) do
+    # This is a MessageTracker normally terminating due to deactivation
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:DOWN, _, :process, _pid, :shutdown}, state) do
+    {:stop, :shutdown, state}
+  end
+
+  @impl true
+  def handle_info({:DOWN, _, :process, _pid, _reason}, state) do
+    {:stop, :monitored_process_died, state}
+  end
+
+  @impl true
+  def handle_info(:timeout, state) do
+    :ok = MessageTracker.deactivate(state.message_tracker)
+
+    {:stop, :normal, state}
+  end
+
+  defp spawn_message_tracker(acknowledger, sharding_key) do
+    name = {:via, Registry, {Registry.MessageTracker, sharding_key}}
+    {:ok, pid} = MessageTracker.start_link(acknowledger: acknowledger, name: name)
+
+    pid
+  end
+end

--- a/lib/consumer/data_updater/handler.ex
+++ b/lib/consumer/data_updater/handler.ex
@@ -1,0 +1,18 @@
+defmodule Mississippi.Consumer.DataUpdater.Handler do
+  @moduledoc """
+  A behaviour module to for implementing a Processor of Mississippi messages.
+  Messages sharing the same sharding key are processed in order.
+  """
+
+  @doc """
+  Invoked when a message is received. A return value of `{:ok, result}` will make Mississippi ack the message,
+  while `{:error, reason}` will make Mississippi discard it.
+  """
+  @callback handle_message(
+              payload :: term(),
+              headers :: map(),
+              message_id :: binary(),
+              timestamp :: term()
+            ) ::
+              {:ok, result :: term()} | {:error, reason :: term()}
+end

--- a/lib/consumer/data_updater/impl.ex
+++ b/lib/consumer/data_updater/impl.ex
@@ -1,0 +1,13 @@
+defmodule Mississippi.Consumer.DataUpdater.Handler.Impl do
+  @behaviour Mississippi.Consumer.DataUpdater.Handler
+
+  @impl true
+  def handle_message(payload, headers, message_id, timestamp) do
+    IO.puts(
+      "Received message #{inspect(message_id)} with payload #{inspect(payload)} and headers #{inspect(headers)}
+      at #{inspect(timestamp |> DateTime.from_unix!())}"
+    )
+
+    {:ok, :ok}
+  end
+end

--- a/lib/consumer/message_tracker.ex
+++ b/lib/consumer/message_tracker.ex
@@ -1,0 +1,60 @@
+defmodule Mississippi.Consumer.MessageTracker do
+  @moduledoc """
+  The MessageTracker process guarantees that messages sharing the same sharding key
+  are processed in (chronological) order.
+  """
+  alias Mississippi.Consumer.MessageTracker.Server
+
+  def start_link(args) do
+    name = Keyword.fetch!(args, :name)
+    GenServer.start_link(Server, args, name: name)
+  end
+
+  @doc """
+  Start tracking a message. This call is not blocking.
+  """
+  def track_delivery(message_tracker, message_id, delivery_tag) do
+    GenServer.cast(message_tracker, {:track_delivery, message_id, delivery_tag})
+  end
+
+  @doc """
+  Add a DataUpdater process that will handle messages tracked by the DataTracker process.
+  This call is blocking, as only one DataUpdater process is allowed to register to a
+  single MessageTracker.
+  """
+  def register_data_updater(message_tracker) do
+    GenServer.call(message_tracker, :register_data_updater, :infinity)
+  end
+
+  @doc """
+  Returns `true` if the caller process can process the message identified by `message_id`,
+  `false` otherwise. This call is blocking, as the confirmation is given only to the first
+  in-order message.
+  """
+  def can_process_message(message_tracker, message_id) do
+    GenServer.call(message_tracker, {:can_process_message, message_id}, :infinity)
+  end
+
+  @doc """
+  Allows the MessageTracker to signal to the AMQPConsumer process to ack the message identified by `message_id`.
+  This call is blocking, as only first in-order message can be acked.
+  """
+  def ack_delivery(message_tracker, message_id) do
+    GenServer.call(message_tracker, {:ack_delivery, message_id})
+  end
+
+  @doc """
+  Allows the MessageTracker to signal to the AMQPConsumer process to discard the message identified by `message_id`.
+  This call is blocking, as only first in-order message can be discarded.
+  """
+  def discard(message_tracker, message_id) do
+    GenServer.call(message_tracker, {:discard, message_id})
+  end
+
+  @doc """
+  Invoked to deactivate a given MessageTracker process.
+  """
+  def deactivate(message_tracker) do
+    GenServer.call(message_tracker, :deactivate, :infinity)
+  end
+end

--- a/lib/consumer/message_tracker/server.ex
+++ b/lib/consumer/message_tracker/server.ex
@@ -1,0 +1,216 @@
+defmodule Mississippi.Consumer.MessageTracker.Server do
+  alias Mississippi.Consumer.AMQPDataConsumer
+  require Logger
+  use GenServer
+
+  @base_backoff 1000
+  @random_backoff 9000
+
+  # TODO: this should probably be a :gen_statem so we can simplify state data
+
+  def init(args) do
+    acknowledger = Keyword.fetch!(args, :acknowledger)
+    {:ok, {:new, :queue.new(), %{}, acknowledger}}
+  end
+
+  def handle_call(:register_data_updater, from, {:new, queue, ids, acknowledger}) do
+    monitor(from)
+    {:reply, :ok, {:accepting, queue, ids, acknowledger}}
+  end
+
+  def handle_call(:register_data_updater, from, {_state, queue, ids, acknowledger}) do
+    Logger.debug("Blocked data updater registration. Queue is #{inspect(queue)}.")
+
+    {:noreply, {{:waiting_cleanup, from}, queue, ids, acknowledger}}
+  end
+
+  def handle_call(
+        {:can_process_message, message_id},
+        from,
+        {:accepting, queue, ids, acknowledger} = s
+      ) do
+    case :queue.peek(queue) do
+      {:value, ^message_id} ->
+        case Map.get(ids, message_id) do
+          nil ->
+            {:noreply, {{:waiting_delivery, from}, queue, ids, acknowledger}}
+
+          {:requeued, _delivery_tag} ->
+            {:noreply, {{:waiting_delivery, from}, queue, ids, acknowledger}}
+
+          _ ->
+            {:reply, true, s}
+        end
+
+      {:value, _} ->
+        {:reply, false, s}
+
+      :empty ->
+        Logger.debug("#{inspect(message_id)} has not been tracked yet. Waiting.")
+        {:noreply, {{:waiting_delivery, message_id, from}, queue, ids, acknowledger}}
+    end
+  end
+
+  def handle_call({:ack_delivery, message_id}, _from, {:accepting, queue, ids, acknowledger}) do
+    {{:value, ^message_id}, new_queue} = :queue.out(queue)
+    {delivery_tag, new_ids} = Map.pop(ids, message_id)
+
+    :ok = ack(acknowledger, delivery_tag)
+
+    {:reply, :ok, {:accepting, new_queue, new_ids, acknowledger}}
+  end
+
+  def handle_call({:discard, message_id}, _from, {:accepting, queue, ids, acknowledger}) do
+    {{:value, ^message_id}, new_queue} = :queue.out(queue)
+    {delivery_tag, new_ids} = Map.pop(ids, message_id)
+
+    :ok = discard(acknowledger, delivery_tag)
+
+    {:reply, :ok, {:accepting, new_queue, new_ids, acknowledger}}
+  end
+
+  def handle_call(:deactivate, _from, {state, queue, ids, _acknowledger} = s) do
+    cond do
+      not :queue.is_empty(queue) ->
+        # We are in a dirty state, so we will not deactivate and we return an error
+        Logger.warning("Refusing to deactivate MessageTracker with non-empty queue.",
+          tag: "message_tracker_deactivate_failed"
+        )
+
+        {:reply, {:error, :deactivate_failed}, s}
+
+      ids != %{} ->
+        # We are in a dirty state, so we will not deactivate and we return an error
+        Logger.warning("Refusing to deactivate MessageTracker with non-empty ids.",
+          tag: "message_tracker_deactivate_failed"
+        )
+
+        {:reply, {:error, :deactivate_failed}, s}
+
+      state != :accepting ->
+        # We are in a dirty state, so we will not deactivate and we return an error
+        Logger.warning("Refusing to deactivate MessageTracker not in :accepting state.",
+          tag: "message_tracker_deactivate_failed"
+        )
+
+        {:reply, {:error, :deactivate_failed}, s}
+
+      true ->
+        # Everything is clean, we can deactivate
+        {:stop, :normal, :ok, s}
+    end
+  end
+
+  def handle_cast(
+        {:track_delivery, message_id, delivery_tag},
+        {{:waiting_delivery, waiting_process}, queue, ids, acknowledger}
+      ) do
+    case Map.get(ids, message_id) do
+      nil ->
+        {new_queue, new_ids} = enqueue_message(queue, ids, message_id, delivery_tag)
+        {:noreply, {{:waiting_delivery, waiting_process}, new_queue, new_ids, acknowledger}}
+
+      {:requeued, _tag} ->
+        new_ids = Map.put(ids, message_id, delivery_tag)
+
+        if :queue.peek(queue) == {:value, message_id} do
+          GenServer.reply(waiting_process, true)
+          {:noreply, {:accepting, queue, new_ids, acknowledger}}
+        else
+          {:noreply, {{:waiting_delivery, waiting_process}, queue, new_ids, acknowledger}}
+        end
+
+      _ ->
+        new_ids = Map.put(ids, message_id, delivery_tag)
+        {:noreply, {{:waiting_delivery, waiting_process}, queue, new_ids, acknowledger}}
+    end
+  end
+
+  def handle_cast(
+        {:track_delivery, message_id, delivery_tag},
+        {state, queue, ids, acknowledger}
+      ) do
+    unless Map.has_key?(ids, message_id) do
+      {new_queue, new_ids} = enqueue_message(queue, ids, message_id, delivery_tag)
+      {:noreply, {state, new_queue, new_ids, acknowledger}}
+    else
+      new_ids = Map.put(ids, message_id, delivery_tag)
+      {:noreply, {state, queue, new_ids, acknowledger}}
+    end
+  end
+
+  def handle_info(
+        {:DOWN, _, :process, _pid, reason},
+        {state, queue, ids, acknowledger} = s
+      ) do
+    Logger.warning("Crash detected. Reason: #{inspect(reason)}, state: #{inspect(s)}.",
+      tag: "data_upd_crash_detected"
+    )
+
+    # TODO
+    # :telemetry.execute([:astarte, :data_updater_plant, :data_updater, :detected_crash], %{}, %{})
+
+    marked_ids =
+      :queue.to_list(queue)
+      |> List.foldl(%{}, fn item, acc ->
+        delivery_tag = ids[item]
+        :ok = requeue(acknowledger, delivery_tag)
+        Map.put(acc, item, {:requeued, delivery_tag})
+      end)
+
+    unless :queue.is_empty(queue) do
+      :rand.uniform(@random_backoff)
+      |> Kernel.+(@base_backoff)
+      |> :timer.sleep()
+    end
+
+    case state do
+      {:waiting_cleanup, waiting_process} ->
+        monitor(waiting_process)
+        GenServer.reply(waiting_process, :ok)
+        {:noreply, {:accepting, queue, marked_ids, acknowledger}}
+
+      _ ->
+        {:noreply, {:new, queue, marked_ids, acknowledger}}
+    end
+  end
+
+  defp monitor({pid, _ref}) do
+    Process.monitor(pid)
+  end
+
+  defp enqueue_message(queue, ids, message_id, delivery_tag) do
+    new_ids = Map.put(ids, message_id, delivery_tag)
+    new_queue = :queue.in(message_id, queue)
+    {new_queue, new_ids}
+  end
+
+  defp requeue(_acknowledger, {:injected_msg, _ref}) do
+    :ok
+  end
+
+  defp requeue(acknowledger, delivery_tag) when is_integer(delivery_tag) do
+    AMQPDataConsumer.requeue(acknowledger, delivery_tag)
+  end
+
+  defp requeue(_acknowledger, {:requeued, delivery_tag}) when is_integer(delivery_tag) do
+    # Do not try to requeue already requeued messages, otherwise channel will crash
+    :ok
+  end
+
+  defp ack(_acknowledger, {:injected_msg, _ref}) do
+    :ok
+  end
+
+  defp ack(acknowledger, delivery_tag) when is_integer(delivery_tag) do
+    AMQPDataConsumer.ack(acknowledger, delivery_tag)
+  end
+
+  defp discard(_acknowledger, {:injected_msg, _ref}) do
+    :ok
+  end
+
+  defp discard(acknowledger, delivery_tag) when is_integer(delivery_tag) do
+    AMQPDataConsumer.discard(acknowledger, delivery_tag)
+  end
+end


### PR DESCRIPTION
Add a consumer side to the Mississippi river. For the moment, this is more or less a porting of what's in https://github.com/astarte-platform/astarte/tree/master/apps/astarte_data_updater_plant, in a Supervision tree structure and using a behaviour instead of the ignominious `impl.ex`.

Quick example:
```elixir
init_options = [amqp_consumer_options: [host: "localhost"], events_consumer_connection_number: 20, mississippi_queues_config: [events_exchange_name: "", data_queue_prefix: "mississippi_", data_queue_range_start: 64, data_queue_range_end: 127, data_queue_total_count: 128] ]
# [...]
Mississippi.Consumer.start_link(init_options)
# {:ok, <pid>}
# ... send a message with Mississippi.Producer ...
# Received message "d79907a4-e96c-45f4-be38-4f8185bffd3a" with payload "a payload" and headers %{"sharding_key" => "a_sharding_key"} at :1715868208
```

Partially based on #1