### PR TITLE
Use signals to update  Handler state 

### DIFF
--- a/lib/consumer/data_updater/handler.ex
+++ b/lib/consumer/data_updater/handler.ex
@@ -26,7 +26,15 @@ defmodule Mississippi.Consumer.DataUpdater.Handler do
               timestamp :: term(),
               state :: handler_state
             ) ::
-              {:ok, result :: term(), state :: handler_state} | {:error, reason :: term()}
+              {:ok, result :: term(), new_state :: handler_state} | {:error, reason :: term()}
+
+  @doc """
+  Invoked when an information that is not a message is received.
+  Used to update the state of a stateful handler.
+  There is no guarantee of ordering.
+  """
+  @callback handle_signal(signal :: term(), state :: handler_state) ::
+              {result :: term(), new_state :: handler_state}
 
   @doc """
   Invoked when the handler is being terminated. It can be used to perform cleanup tasks before closing.

--- a/lib/consumer/data_updater/impl.ex
+++ b/lib/consumer/data_updater/impl.ex
@@ -17,6 +17,13 @@ defmodule Mississippi.Consumer.DataUpdater.Handler.Impl do
   end
 
   @impl true
+  def handle_signal(signal, state) do
+    IO.puts("Received signal #{inspect(signal)}")
+
+    {:ok, state}
+  end
+
+  @impl true
   def terminate(reason, state) do
     IO.puts("Terminating on #{inspect(reason)}, state: #{inspect(state)}")
     :ok


### PR DESCRIPTION
Sometimes, you need to update the state of a stateful Handler without using a Mississippi message.
Introduce the concept of "signal": an information that is directly forwarded to the handler process, without being tracked. 

The signal is still identified by the sharding key of the handler and can be any term.

Update the `Mississippi.Consumer.DataUpdater.Handler` behaviour accordingly. Calling for a signal to be handled is a blocking operation.

Based on #4