### PR TITLE
Consumer: redesign the supervision tree

### DIFF
--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -42,12 +42,10 @@ defmodule Mississippi.Consumer do
       )
 
     children = [
-      {Registry, [keys: :unique, name: Registry.MessageTracker]},
-      {Registry, [keys: :unique, name: Registry.DataUpdater]},
       {ExRabbitPool.PoolSupervisor,
        rabbitmq_config: amqp_consumer_options,
        connection_pools: [events_consumer_pool_config(connection_number)]},
-      {ConsumersSupervisor, queue_config: queue_config, message_handler: message_handler}
+      {ConsumersSupervisor, queues: queue_config, message_handler: message_handler}
     ]
 
     Supervisor.init(children, strategy: :rest_for_one)

--- a/lib/consumer/amqp_data_consumer_supervisor.ex
+++ b/lib/consumer/amqp_data_consumer_supervisor.ex
@@ -10,17 +10,17 @@ defmodule Mississippi.Consumer.AMQPDataConsumer.Supervisor do
   @impl true
   def init(init_arg) do
     children =
-      amqp_data_consumers_childspecs(init_arg[:queue_config], init_arg[:message_handler])
+      amqp_data_consumers_childspecs(init_arg[:queues_config])
 
     opts = [strategy: :one_for_one, name: __MODULE__]
 
     Supervisor.init(children, opts)
   end
 
-  defp amqp_data_consumers_childspecs(queue_config, message_handler) do
-    queue_range_start = queue_config[:range_start]
-    queue_range_end = queue_config[:range_end]
-    queue_prefix = queue_config[:prefix]
+  defp amqp_data_consumers_childspecs(queues_config) do
+    queue_range_start = queues_config[:range_start]
+    queue_range_end = queues_config[:range_end]
+    queue_prefix = queues_config[:prefix]
 
     for queue_index <- queue_range_start..queue_range_end do
       queue_name = "#{queue_prefix}#{queue_index}"
@@ -30,8 +30,7 @@ defmodule Mississippi.Consumer.AMQPDataConsumer.Supervisor do
         queue_index: queue_index,
         range_start: queue_range_start,
         range_end: queue_range_end,
-        queue_total_count: queue_config[:total_count],
-        message_handler: message_handler
+        queue_total_count: queues_config[:total_count]
       ]
 
       Supervisor.child_spec({AMQPDataConsumer, init_args}, id: {AMQPDataConsumer, queue_index})

--- a/lib/consumer/data_updater.ex
+++ b/lib/consumer/data_updater.ex
@@ -10,8 +10,8 @@ defmodule Mississippi.Consumer.DataUpdater do
 
   use GenServer
 
-  alias Mississippi.Consumer.AMQPDataConsumer
   alias Mississippi.Consumer.MessageTracker
+  alias Mississippi.Consumer.DataUpdater
   require Logger
 
   # TODO make this configurable?
@@ -19,11 +19,12 @@ defmodule Mississippi.Consumer.DataUpdater do
 
   @doc """
   Start handling a message. If it is the first in-order message, it will be processed
-  straight away by the `message_handler` (which is a module implementing DataUpdater.Handler behaviour).
+  straight away by the `message_handler` provided in the mississippi config
+  (which is a module implementing DataUpdater.Handler behaviour).
   If not, the message will remain in memory until it can be processed, i.e. it is now the first
   in-order message.
   """
-  def handle_message(sharding_key, payload, headers, tracking_id, timestamp, message_handler) do
+  def handle_message(sharding_key, payload, headers, tracking_id, timestamp) do
     message_tracker = get_message_tracker(sharding_key)
     {message_id, delivery_tag} = tracking_id
     MessageTracker.track_delivery(message_tracker, message_id, delivery_tag)

--- a/lib/consumer/data_updater.ex
+++ b/lib/consumer/data_updater.ex
@@ -28,7 +28,7 @@ defmodule Mississippi.Consumer.DataUpdater do
     {message_id, delivery_tag} = tracking_id
     MessageTracker.track_delivery(message_tracker, message_id, delivery_tag)
 
-    get_data_updater_process(sharding_key, message_tracker, message_handler)
+    get_data_updater_process(sharding_key)
     |> GenServer.cast({:handle_message, payload, headers, message_id, timestamp})
   end
 
@@ -37,76 +37,90 @@ defmodule Mississippi.Consumer.DataUpdater do
   but is not a Mississippi message. Used to change the state of
   a stateful Handler. The call is blocking and there is no ordering guarantee.
   """
-  def handle_signal(sharding_key, signal, message_handler) do
-    message_tracker = get_message_tracker(sharding_key)
-
-    get_data_updater_process(sharding_key, message_tracker, message_handler)
+  def handle_signal(sharding_key, signal) do
+    get_data_updater_process(sharding_key)
     |> GenServer.call({:handle_signal, signal})
   end
 
   @doc """
   Provides a reference to the DataUpdater process that will handle the set of messages identified by
-  the given sharding key. Messages going through the DataUpdater process will be tracked by the
-  `message_tracker` and the `message_handler` will be used to process them.
+  the given sharding key.
   """
-  def get_data_updater_process(sharding_key, message_tracker, message_handler, opts \\ []) do
-    case Registry.lookup(Registry.DataUpdater, sharding_key) do
-      [] ->
-        if Keyword.get(opts, :offload_start) do
-          # We pass through AMQPDataConsumer to start the process to make sure that
-          # that start is serialized
-          AMQPDataConsumer.start_data_updater(sharding_key, message_tracker)
-        else
-          name = {:via, Registry, {Registry.DataUpdater, sharding_key}}
-          {:ok, pid} = start(sharding_key, message_tracker, message_handler, name: name)
-          pid
-        end
-
-      [{pid, nil}] ->
+  def get_data_updater_process(sharding_key) do
+    # TODO bring back :offload_start (?)
+    case DataUpdater.Supervisor.start_child({DataUpdater, sharding_key: sharding_key}) do
+      {:ok, pid} ->
         pid
+
+      {:ok, pid, _info} ->
+        pid
+
+      {:error, {:already_started, pid}} ->
+        pid
+
+      other ->
+        _ =
+          Logger.warning(
+            "Could not start DataUpdater process for sharding_key #{inspect(sharding_key)}: #{inspect(other)}",
+            tag: "data_updater_start_fail"
+          )
+
+        {:error, :data_updater_start_fail}
     end
   end
 
   @doc """
   Provides a reference to the MessageTracker process that will track the set of messages identified by
-  the given sharding key. The MessageTracker process is linked to the one calling this function.
+  the given sharding key.
+  The MessageTracker will use the process calling this function to ack messages (TODO change this).
   """
-  def get_message_tracker(sharding_key, opts \\ []) do
-    case Registry.lookup(Registry.MessageTracker, sharding_key) do
-      [] ->
-        if Keyword.get(opts, :offload_start) do
-          # We pass through AMQPDataConsumer to start the process to make sure that
-          # that start is serialized and acknowledger is the right process
-          AMQPDataConsumer.start_message_tracker(sharding_key)
-        else
-          acknowledger = self()
-          spawn_message_tracker(acknowledger, sharding_key)
-        end
+  def get_message_tracker(sharding_key) do
+    # TODO we will move away from having the DataUpdater to ack messages, but for now let's keep it as it was
+    acknowledger = self()
+    name = {:via, Registry, {Registry.MessageTracker, {:sharding_key, sharding_key}}}
 
-      [{pid, nil}] ->
+    # TODO bring back :offload_start (?)
+    case DynamicSupervisor.start_child(
+           MessageTracker.Supervisor,
+           {MessageTracker.Server, name: name, acknowledger: acknowledger}
+         ) do
+      {:ok, pid} ->
         pid
+
+      {:ok, pid, _info} ->
+        pid
+
+      {:error, {:already_started, pid}} ->
+        pid
+
+      other ->
+        _ =
+          Logger.warning(
+            "Could not start MessageTracker process for sharding_key #{inspect(sharding_key)}: #{inspect(other)}",
+            tag: "message_tracker_start_fail"
+          )
+
+        {:error, :message_tracker_start_fail}
     end
   end
 
-  @doc """
-  Starts a DataUpdater process that will handle the set of messages identified by
-  `sharding_key`. Messages going through the DataUpdater process will be tracked by the
-  `message_tracker` and the `message_handler` will be used to process them.
-  """
-  def start(sharding_key, message_tracker, message_handler, opts \\ []) do
-    init_arg = [
+  def start_link(extra_args, start_args) do
+    {:message_handler, message_handler} = extra_args
+    sharding_key = Keyword.fetch!(start_args, :sharding_key)
+
+    init_args = [
       sharding_key: sharding_key,
-      message_tracker: message_tracker,
       message_handler: message_handler
     ]
 
-    GenServer.start(__MODULE__, init_arg, opts)
+    name = {:via, Registry, {Registry.DataUpdater, {:sharding_key, sharding_key}}}
+    GenServer.start_link(__MODULE__, init_args, name: name)
   end
 
   @impl true
   def init(init_arg) do
     sharding_key = Keyword.fetch!(init_arg, :sharding_key)
-    message_tracker = Keyword.fetch!(init_arg, :message_tracker)
+    message_tracker = get_message_tracker(sharding_key)
     message_handler = Keyword.fetch!(init_arg, :message_handler)
 
     MessageTracker.register_data_updater(message_tracker)
@@ -192,12 +206,5 @@ defmodule Mississippi.Consumer.DataUpdater do
     %State{message_handler: message_handler, handler_state: handler_state} = state
     message_handler.terminate(reason, handler_state)
     :ok
-  end
-
-  defp spawn_message_tracker(acknowledger, sharding_key) do
-    name = {:via, Registry, {Registry.MessageTracker, sharding_key}}
-    {:ok, pid} = MessageTracker.start_link(acknowledger: acknowledger, name: name)
-
-    pid
   end
 end

--- a/lib/consumer/data_updater_supervisor.ex
+++ b/lib/consumer/data_updater_supervisor.ex
@@ -1,0 +1,32 @@
+defmodule Mississippi.Consumer.DataUpdater.Supervisor do
+  require Logger
+  use DynamicSupervisor
+
+  def start_link(init_args) do
+    DynamicSupervisor.start_link(__MODULE__, init_args, name: __MODULE__)
+  end
+
+  @impl true
+  def init(init_args) do
+    _ = Logger.info("Starting DataUpdater supervisor", tag: "data_updater_supervisor_start")
+    DynamicSupervisor.init(strategy: :one_for_one, extra_arguments: init_args)
+  end
+
+  def start_child(child) do
+    _ =
+      Logger.info("Adding a new DataUpdater",
+        tag: "data_updater_add"
+      )
+
+    DynamicSupervisor.start_child(__MODULE__, child)
+  end
+
+  def terminate_child(pid) do
+    _ =
+      Logger.info("Terminating a DataUpdater",
+        tag: "data_updater_terminate"
+      )
+
+    DynamicSupervisor.terminate_child(__MODULE__, pid)
+  end
+end

--- a/lib/consumer/message_tracker.ex
+++ b/lib/consumer/message_tracker.ex
@@ -3,12 +3,6 @@ defmodule Mississippi.Consumer.MessageTracker do
   The MessageTracker process guarantees that messages sharing the same sharding key
   are processed in (chronological) order.
   """
-  alias Mississippi.Consumer.MessageTracker.Server
-
-  def start_link(args) do
-    name = Keyword.fetch!(args, :name)
-    GenServer.start_link(Server, args, name: name)
-  end
 
   @doc """
   Start tracking a message. This call is not blocking.

--- a/lib/consumer/message_tracker/server.ex
+++ b/lib/consumer/message_tracker/server.ex
@@ -8,8 +8,14 @@ defmodule Mississippi.Consumer.MessageTracker.Server do
 
   # TODO: this should probably be a :gen_statem so we can simplify state data
 
-  def init(args) do
-    acknowledger = Keyword.fetch!(args, :acknowledger)
+  def start_link(args) do
+    name = Keyword.fetch!(args, :name)
+    _ = Logger.info("Starting MessageTracker #{inspect(name)}", tag: "message_tracker_start")
+    GenServer.start_link(__MODULE__, args, name: name)
+  end
+
+  def init(init_args) do
+    acknowledger = Keyword.fetch!(init_args, :acknowledger)
     {:ok, {:new, :queue.new(), %{}, acknowledger}}
   end
 


### PR DESCRIPTION
Now, each `DataUpdater`, `MessageTracker`, `DataConsumer` process is supervised.
`DataConsumer`s are statically supervised, as we expect queues to be always there, while `MessageTracker`s and `DataUpdater`s can start and terminate dynamically.
Moreover, decouple the spawning of processes, while maintaining the same links/monitors as before, using a conceptual framework similar to Orleans, i.e. virtual actors (our processes) can be activated (spawned) when a reference to them is needed.
As an example, a `DataConsumer` process does not hold a reference to a `MessageTracker` process anymore, but rather it requires it from the `MessageTracker.Supervisor` when message tracking functions are called. 

This change only affects the internals of the consumer application.