### PR TITLE
Consumer: revamp message tracking

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  import_deps: [:typed_struct]
 ]

--- a/lib/consumer/amqp_data_consumer.ex
+++ b/lib/consumer/amqp_data_consumer.ex
@@ -1,19 +1,16 @@
 defmodule Mississippi.Consumer.AMQPDataConsumer do
-  defmodule State do
-    defstruct [
-      :channel,
-      :monitor,
-      :queue_name,
-      :queue_range,
-      :queue_total_count
-    ]
-  end
+  @moduledoc """
+  The AMQPDataConsumer process fetches messages from a Mississippi AMQP queue and
+  sends them to MessageTrackers according to the message sharding key.
+  """
 
   require Logger
   use GenServer
 
   alias AMQP.Channel
-  alias Mississippi.Consumer.DataUpdater
+  alias Mississippi.Consumer.AMQPDataConsumer.State
+  alias Mississippi.Consumer.Message
+  alias Mississippi.Consumer.MessageTracker
 
   # TODO should this be customizable?
   @reconnect_interval 1_000
@@ -28,54 +25,15 @@ defmodule Mississippi.Consumer.AMQPDataConsumer do
     GenServer.start_link(__MODULE__, args, name: get_queue_via_tuple(index))
   end
 
-  def ack(pid, delivery_tag) do
-    Logger.debug("Going to ack #{inspect(delivery_tag)}")
-    GenServer.call(pid, {:ack, delivery_tag})
-  end
-
-  def discard(pid, delivery_tag) do
-    Logger.debug("Going to discard #{inspect(delivery_tag)}")
-    GenServer.call(pid, {:discard, delivery_tag})
-  end
-
-  def requeue(pid, delivery_tag) do
-    Logger.debug("Going to requeue #{inspect(delivery_tag)}")
-    GenServer.call(pid, {:requeue, delivery_tag})
-  end
-
-  def start_message_tracker(sharding_key) do
-    with {:ok, via_tuple} <- fetch_queue_via_tuple(sharding_key) do
-      GenServer.call(via_tuple, {:start_message_tracker, sharding_key})
-    end
-  end
-
-  def start_data_updater(sharding_key, message_tracker) do
-    with {:ok, via_tuple} <- fetch_queue_via_tuple(sharding_key) do
-      GenServer.call(via_tuple, {:start_data_updater, sharding_key, message_tracker})
-    end
-  end
-
-  defp get_queue_via_tuple(queue_index) when is_integer(queue_index) do
-    {:via, Registry, {Registry.AMQPDataConsumer, {:queue_index, queue_index}}}
-  end
-
-  defp fetch_queue_via_tuple(sharding_key) do
-    GenServer.call(self(), {:fetch_queue_via_tuple, sharding_key})
-  end
-
   # Server callbacks
 
   @impl true
   def init(args) do
     queue_name = Keyword.fetch!(args, :queue_name)
-    queue_range_start = Keyword.fetch!(args, :range_start)
-    queue_range_end = Keyword.fetch!(args, :range_end)
-    queue_count = Keyword.fetch!(args, :queue_total_count)
 
     state = %State{
       queue_name: queue_name,
-      queue_range: queue_range_start..queue_range_end,
-      queue_total_count: queue_count
+      monitors: []
     }
 
     {:ok, state, {:continue, :init_consume}}
@@ -85,75 +43,18 @@ defmodule Mississippi.Consumer.AMQPDataConsumer do
   def handle_continue(:init_consume, state), do: init_consume(state)
 
   @impl true
-  def handle_call({:ack, delivery_tag}, _from, %State{channel: chan} = state) do
-    res = @adapter.ack(chan, delivery_tag)
-    {:reply, res, state}
-  end
-
-  def handle_call({:discard, delivery_tag}, _from, %State{channel: chan} = state) do
-    res = @adapter.reject(chan, delivery_tag, requeue: false)
-    {:reply, res, state}
-  end
-
-  def handle_call({:requeue, delivery_tag}, _from, %State{channel: chan} = state) do
-    res = @adapter.reject(chan, delivery_tag, requeue: true)
-    {:reply, res, state}
-  end
-
-  # TODO this was (seemed to be) unused
-  def handle_call({:start_message_tracker, sharding_key}, _from, state) do
-    res = DataUpdater.get_message_tracker(sharding_key)
-    {:reply, res, state}
-  end
-
-  # TODO this was (seemed to be) unused
-  def handle_call({:start_data_updater, sharding_key, _message_tracker}, _from, state) do
-    res = DataUpdater.get_data_updater_process(sharding_key)
-    {:reply, res, state}
-  end
-
-  def handle_call({:fetch_queue_via_tuple, sharding_key}, _from, state) do
-    %State{
-      queue_total_count: queue_count,
-      queue_range: queue_range
-    } = state
-
-    # TODO refactor: bring out the algorithm
-    # This is the same sharding algorithm used in producer
-    # Make sure they stay in sync
-    queue_index = :erlang.phash2(sharding_key, queue_count)
-
-    if queue_index in queue_range do
-      {:reply, {:ok, get_queue_via_tuple(queue_index)}, state}
-    else
-      {:reply, {:error, :unhandled_device}, state}
-    end
-  end
-
-  @impl true
   def handle_info(:init_consume, state), do: init_consume(state)
 
+  # This is a Message Tracker deactivating itself normally, just remove its monitor.
+  # In case a messageTracker crashes, we want to crash too, so that messages are requeued.
   def handle_info(
         {:DOWN, _, :process, pid, :normal},
         %State{channel: %Channel{pid: chan_pid}} = state
       )
       when pid != chan_pid do
-    # This is a Message Tracker deactivating itself normally, do nothing
-    {:noreply, state}
-  end
-
-  # Make sure to handle monitored message trackers exit messages
-  # Under the hood DataUpdater calls Process.monitor so those monitor are leaked into this process.
-  def handle_info(
-        {:DOWN, monitor, :process, chan_pid, reason},
-        %{monitor: monitor, channel: %{pid: chan_pid}} = state
-      ) do
-    # Channel went down, stop the process
-    Logger.warning("AMQP data consumer crashed, reason: #{inspect(reason)}",
-      tag: "data_consumer_chan_crash"
-    )
-
-    init_consume(%State{state | channel: nil, monitor: nil})
+    %State{monitors: monitors} = state
+    new_monitors = List.delete(monitors, pid)
+    {:noreply, %State{state | monitors: new_monitors}}
   end
 
   # Confirmation sent by the broker after registering this process as a consumer
@@ -173,22 +74,49 @@ defmodule Mississippi.Consumer.AMQPDataConsumer do
 
   # Message consumed
   def handle_info({:basic_deliver, payload, meta}, state) do
-    %State{channel: chan} = state
+    %State{channel: channel, monitors: monitors} = state
     {headers, no_headers_meta} = Map.pop(meta, :headers, [])
     headers_map = amqp_headers_to_map(headers)
 
     {timestamp, clean_meta} = Map.pop(no_headers_meta, :timestamp)
 
-    case handle_consume(payload, headers_map, timestamp, clean_meta) do
-      :ok ->
-        :ok
+    message = %Message{
+      payload: payload,
+      headers: headers_map,
+      timestamp: timestamp,
+      meta: clean_meta
+    }
 
-      :invalid_msg ->
+    case message.headers do
+      %{@sharding_key => sharding_key_binary} ->
+        sharding_key = :erlang.binary_to_term(sharding_key_binary)
+        {:ok, mt_pid} = MessageTracker.get_message_tracker(sharding_key)
+
+        new_monitors = maybe_update_monitors(mt_pid, monitors)
+
+        MessageTracker.handle_message(mt_pid, message, channel)
+        new_state = %State{state | monitors: new_monitors}
+        {:noreply, new_state}
+
+      _ ->
+        handle_invalid_msg(message)
         # ACK invalid msg to discard them
-        @adapter.ack(chan, meta.delivery_tag)
+        @adapter.ack(channel, meta.delivery_tag)
+        {:noreply, state}
     end
+  end
 
-    {:noreply, state}
+  defp maybe_update_monitors(pid, monitors) do
+    if pid in monitors do
+      monitors
+    else
+      Process.monitor(pid)
+      [pid | monitors]
+    end
+  end
+
+  defp get_queue_via_tuple(queue_index) when is_integer(queue_index) do
+    {:via, Registry, {Registry.AMQPDataConsumer, {:queue_index, queue_index}}}
   end
 
   defp schedule_connect() do
@@ -210,7 +138,7 @@ defmodule Mississippi.Consumer.AMQPDataConsumer do
           )
 
         schedule_connect()
-        {:noreply, state}
+        {:noreply, %State{state | channel: nil}}
     end
   end
 
@@ -221,14 +149,14 @@ defmodule Mississippi.Consumer.AMQPDataConsumer do
     with :ok <- @adapter.qos(channel, prefetch_count: @consumer_prefetch_count),
          {:ok, _queue} <- @adapter.declare_queue(channel, queue_name, durable: true),
          {:ok, _consumer_tag} <- @adapter.consume(channel, queue_name, self()) do
-      ref = Process.monitor(channel_pid)
+      Process.link(channel_pid)
 
       _ =
         Logger.debug("AMQPDataConsumer for queue #{queue_name} initialized",
           tag: "data_consumer_init_ok"
         )
 
-      {:noreply, %State{state | channel: channel, monitor: ref}}
+      {:noreply, %State{state | channel: channel}}
     else
       {:error, reason} ->
         Logger.warning(
@@ -239,28 +167,14 @@ defmodule Mississippi.Consumer.AMQPDataConsumer do
         # Something went wrong, let's put the channel back where it belongs
         _ = ExRabbitPool.checkin_channel(conn, channel)
         schedule_connect()
-        {:noreply, %{state | channel: nil, monitor: nil}}
+        {:noreply, %State{state | channel: nil}}
     end
   end
 
-  defp handle_consume(payload, headers, timestamp, meta) do
-    with %{@sharding_key => sharding_key_binary} <- headers,
-         {:ok, tracking_id} <- get_tracking_id(meta) do
-      sharding_key = :erlang.binary_to_term(sharding_key_binary)
-      # This call might spawn processes and implicitly monitor them
-      DataUpdater.handle_message(
-        sharding_key,
-        payload,
-        headers,
-        tracking_id,
-        timestamp
-      )
-    else
-      _ -> handle_invalid_msg(payload, headers, timestamp, meta)
-    end
-  end
+  defp handle_invalid_msg(message) do
+    %Message{payload: payload, headers: headers, timestamp: timestamp, meta: meta} =
+      message
 
-  defp handle_invalid_msg(payload, headers, timestamp, meta) do
     Logger.warning(
       "Invalid AMQP message: #{inspect(Base.encode64(payload))} #{inspect(headers)} #{inspect(timestamp)} #{inspect(meta)}",
       tag: "data_consumer_invalid_msg"
@@ -273,16 +187,5 @@ defmodule Mississippi.Consumer.AMQPDataConsumer do
     Enum.reduce(headers, %{}, fn {key, _type, value}, acc ->
       Map.put(acc, key, value)
     end)
-  end
-
-  defp get_tracking_id(meta) do
-    message_id = meta.message_id
-    delivery_tag = meta.delivery_tag
-
-    if is_binary(message_id) and is_integer(delivery_tag) do
-      {:ok, {meta.message_id, meta.delivery_tag}}
-    else
-      {:error, :invalid_message_metadata}
-    end
   end
 end

--- a/lib/consumer/amqp_data_consumer/state.ex
+++ b/lib/consumer/amqp_data_consumer/state.ex
@@ -1,0 +1,9 @@
+defmodule Mississippi.Consumer.AMQPDataConsumer.State do
+  use TypedStruct
+
+  typedstruct do
+    field :queue_name, String.t(), enforce: true
+    field :monitors, list(), enforce: true
+    field :channel, term()
+  end
+end

--- a/lib/consumer/amqp_data_consumer_supervisor.ex
+++ b/lib/consumer/amqp_data_consumer_supervisor.ex
@@ -27,10 +27,7 @@ defmodule Mississippi.Consumer.AMQPDataConsumer.Supervisor do
 
       init_args = [
         queue_name: queue_name,
-        queue_index: queue_index,
-        range_start: queue_range_start,
-        range_end: queue_range_end,
-        queue_total_count: queues_config[:total_count]
+        queue_index: queue_index
       ]
 
       Supervisor.child_spec({AMQPDataConsumer, init_args}, id: {AMQPDataConsumer, queue_index})

--- a/lib/consumer/data_updater/handler.ex
+++ b/lib/consumer/data_updater/handler.ex
@@ -17,7 +17,7 @@ defmodule Mississippi.Consumer.DataUpdater.Handler do
 
   @doc """
   Invoked when a message is received. A return value of `{:ok, result, state}` will make Mississippi ack the message,
-  while `{:error, reason, state}` will make Mississippi discard it.
+  while `{:error, reason, state}` will make Mississippi reject it.
   """
   @callback handle_message(
               payload :: term(),
@@ -26,7 +26,8 @@ defmodule Mississippi.Consumer.DataUpdater.Handler do
               timestamp :: term(),
               state :: handler_state
             ) ::
-              {:ok, result :: term(), new_state :: handler_state} | {:error, reason :: term()}
+              {:ok, result :: term(), new_state :: handler_state}
+              | {:error, reason :: term(), state :: handler_state}
 
   @doc """
   Invoked when an information that is not a message is received.

--- a/lib/consumer/data_updater/state.ex
+++ b/lib/consumer/data_updater/state.ex
@@ -1,0 +1,9 @@
+defmodule Mississippi.Consumer.DataUpdater.State do
+  use TypedStruct
+
+  typedstruct do
+    field :sharding_key, term(), enforce: true
+    field :message_handler, module(), enforce: true
+    field :handler_state, term(), enforce: true
+  end
+end

--- a/lib/consumer/data_updater_supervisor.ex
+++ b/lib/consumer/data_updater_supervisor.ex
@@ -13,11 +13,6 @@ defmodule Mississippi.Consumer.DataUpdater.Supervisor do
   end
 
   def start_child(child) do
-    _ =
-      Logger.info("Adding a new DataUpdater",
-        tag: "data_updater_add"
-      )
-
     DynamicSupervisor.start_child(__MODULE__, child)
   end
 

--- a/lib/consumer/message.ex
+++ b/lib/consumer/message.ex
@@ -1,0 +1,10 @@
+defmodule Mississippi.Consumer.Message do
+  use TypedStruct
+
+  typedstruct do
+    field :payload, term(), enforce: true
+    field :headers, map(), enforce: true
+    field :timestamp, term(), enforce: true
+    field :meta, term(), enforce: true
+  end
+end

--- a/lib/consumer/message_tracker/state.ex
+++ b/lib/consumer/message_tracker/state.ex
@@ -1,0 +1,13 @@
+defmodule Mississippi.Consumer.MessageTracker.Server.State do
+  use TypedStruct
+
+  typedstruct do
+    field :queue, term(), enforce: true
+
+    field :sharding_key, term(), enforce: true
+
+    field :data_updater_pid, pid()
+
+    field :channel, AMQP.Channel.t()
+  end
+end

--- a/lib/producer/events_producer.ex
+++ b/lib/producer/events_producer.ex
@@ -3,19 +3,11 @@ defmodule Mississippi.Producer.EventsProducer do
   The entry point for publishing messages on Mississippi.
   """
 
-  defmodule State do
-    defstruct [
-      :channel,
-      :events_exchange_name,
-      :queue_total_count,
-      :queue_prefix
-    ]
-  end
-
   use GenServer
 
   alias AMQP.Channel
   alias Mississippi.Producer.EventsProducer.Options
+  alias Mississippi.Producer.EventsProducer.State
   require Logger
 
   # TODO should these be customizable?

--- a/lib/producer/events_producer/state.ex
+++ b/lib/producer/events_producer/state.ex
@@ -1,0 +1,10 @@
+defmodule Mississippi.Producer.EventsProducer.State do
+  use TypedStruct
+
+  typedstruct do
+    field :events_exchange_name, String.t(), enforce: true
+    field :queue_prefix, String.t(), enforce: true
+    field :queue_total_count, pos_integer(), enforce: true
+    field :channel, term()
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -25,11 +25,12 @@ defmodule Mississippi.MixProject do
       {:dialyxir, "~> 1.4", only: [:dev, :ci], runtime: false},
       {:elixir_uuid, "~> 1.2"},
       {:excoveralls, "~> 0.18", only: :test},
-      {:nimble_options, "~> 1.0"},
-      {:pretty_log, "~> 0.1"},
       # hex.pm package and esl/ex_rabbit_pool do not support amqp version 2.1.
       # This fork is supporting amqp ~> 2.0 and also ~> 3.0.
-      {:ex_rabbit_pool, github: "leductam/ex_rabbit_pool"}
+      {:ex_rabbit_pool, github: "leductam/ex_rabbit_pool"},
+      {:nimble_options, "~> 1.0"},
+      {:pretty_log, "~> 0.1"},
+      {:typed_struct, "~> 0.3.0"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -15,4 +15,5 @@
   "rabbit_common": {:hex, :rabbit_common, "3.12.14", "466123ee7346a3cdac078c0c302bcd36da4523e8acd678c1b992f7b4df1f7914", [:make, :rebar3], [{:credentials_obfuscation, "3.4.0", [hex: :credentials_obfuscation, repo: "hexpm", optional: false]}, {:recon, "2.5.3", [hex: :recon, repo: "hexpm", optional: false]}, {:thoas, "1.0.0", [hex: :thoas, repo: "hexpm", optional: false]}], "hexpm", "70c31a51f7401cc0204ddef2745d98680c2e0df67e3b0c9e198916881fde3293"},
   "recon": {:hex, :recon, "2.5.3", "739107b9050ea683c30e96de050bc59248fd27ec147696f79a8797ff9fa17153", [:mix, :rebar3], [], "hexpm", "6c6683f46fd4a1dfd98404b9f78dcabc7fcd8826613a89dcb984727a8c3099d7"},
   "thoas": {:hex, :thoas, "1.0.0", "567c03902920827a18a89f05b79a37b5bf93553154b883e0131801600cf02ce0", [:rebar3], [], "hexpm", "fc763185b932ecb32a554fb735ee03c3b6b1b31366077a2427d2a97f3bd26735"},
+  "typed_struct": {:hex, :typed_struct, "0.3.0", "939789e3c1dca39d7170c87f729127469d1315dcf99fee8e152bb774b17e7ff7", [:mix], [], "hexpm", "c50bd5c3a61fe4e198a8504f939be3d3c85903b382bde4865579bc23111d1b6d"},
 }


### PR DESCRIPTION
> _"Se vogliamo che tutto rimanga com’è, bisogna che tutto cambi”_

(Tancredi in "Il Gattopardo", by G. Tomasi di Lampedusa)

### What
Essentially, revisit the internals of the consumer application to remove old and messy code. The new supervision structure brought forward in #6 was the first step, and now the actual implementation of AMQPDataConsumer, MessageTracker and DataUpdater is simplified.

At a first glance, the most relevant change is that it is the MessageTracker (and not the AMQPDataConsumer) tasked with ack-/reject-ing a message, once processing is done. This allows to remove a level of indirection and communication between processes, making the system more reliable and fault-tolerant, because the application state is less distributed.

### Message flow
The standard message flow is now as follows:
![mississippi_flow drawio](https://github.com/user-attachments/assets/e5c7a856-a57f-4ba9-b3d1-ad2cd6137cd7)

This allows the MessageTracker to maintain the ordering invariant. Internally, it does so by keeping a FIFO queue of messages in its state, and checking that only the message on top of the queue is being processed at any given time.

There exist only one AMQPDataConsumer per queue, and only one MessageTracker and DataUpdater per sharding key. This allows for an AMQPDataConsumer to forward messages to more than one MessageTracker, but a given MessageTracker can receive messages from a single AMQPDataConsumer only. Moreover, only one MessageTracker and one DataUpdater exist for a given sharding key at any given time.

### Fault handling
The supervision tree is now as follows (see #6 for more)
![mississippi_consumer_supervision_tree drawio](https://github.com/user-attachments/assets/32999955-fafe-47c5-b76a-8ad520edea76)

- The AMQPDataConsumer monitors each MessageTracker to which it is sending messages, so that if they crash, it crashes too and messages are put back in the AMQP queues
- The AMQPDataConsumer is linked to the AMQP Channel it receives messages from so that in case of a channel crash, it crashes too and messages are put back in the AMQP queues
- The MessageTracker monitors the DataUpdater to which it is sending messages, so that if it crashes, it can request another DataUpdater process for the same key and let the new process handle the message
- The MessageTracker monitors the AMQP Channel from which it is receiving (via AMQPDataConsumer) messages, so that if the channel crashes, it crashes too and messages are put back in the AMQP queues

