### PR TITLE
Consumer: extend unit tests

### DIFF
--- a/lib/consumer/data_updater.ex
+++ b/lib/consumer/data_updater.ex
@@ -8,6 +8,7 @@ defmodule Mississippi.Consumer.DataUpdater do
   """
 
   use GenServer, restart: :transient
+  use Efx
 
   alias Mississippi.Consumer.DataUpdater
   alias Mississippi.Consumer.DataUpdater.State
@@ -43,7 +44,7 @@ defmodule Mississippi.Consumer.DataUpdater do
   """
   @spec get_data_updater_process(sharding_key :: term()) ::
           {:ok, pid()} | {:error, :data_updater_start_fail}
-  def get_data_updater_process(sharding_key) do
+  defeffect get_data_updater_process(sharding_key) do
     # TODO bring back :offload_start (?)
     case DataUpdater.Supervisor.start_child({DataUpdater, sharding_key: sharding_key}) do
       {:ok, pid} ->

--- a/test/consumer/amqp_data_consumer_test.exs
+++ b/test/consumer/amqp_data_consumer_test.exs
@@ -1,5 +1,5 @@
 defmodule Mississippi.Consumer.AMQPDataConsumer.Test do
-  use EfxCase
+  use EfxCase, async: false
 
   # We use Mox here because we don't care about the type safety
   # guarantees of Hammox
@@ -7,13 +7,170 @@ defmodule Mississippi.Consumer.AMQPDataConsumer.Test do
 
   alias AMQP.Channel
   alias Mississippi.Consumer.AMQPDataConsumer
+  alias Mississippi.Consumer.AMQPDataConsumer.State
   alias Mississippi.Consumer.MessageTracker
+  alias Mississippi.Consumer.Test.Placeholder
 
   require Logger
 
-  setup_all do
-    start_supervised!({Registry, [keys: :unique, name: Registry.AMQPDataConsumer]})
+  @moduletag :unit
 
+  doctest Mississippi.Consumer.AMQPDataConsumer
+
+  setup_all do
+    start_supervised({Registry, [keys: :unique, name: Registry.AMQPDataConsumer]})
+    :ok
+  end
+
+  describe "AMQPDataConsumer message handling:" do
+    setup :create_queue_index
+    setup :create_sharding_key
+    setup :create_payload
+    setup :create_meta
+    setup :setup_mock_message_tracker
+    setup :setup_mox
+
+    @tag :data_consumer_message_handling
+    test "Messages are forwarded to different trackers based on sharding key", %{
+      queue_index: queue_index
+    } do
+      data_consumer_pid =
+        start_supervised!(
+          {AMQPDataConsumer, queue_index: queue_index, queue_name: "queue_#{queue_index}"},
+          id: {AMQPDataConsumer, queue_index}
+        )
+
+      sharding_key_1 = get_sharding_key()
+      sharding_key_2 = get_sharding_key()
+
+      tracker_1 = get_message_tracker()
+      tracker_2 = get_message_tracker()
+
+      trackers = %{
+        sharding_key_1 => tracker_1,
+        sharding_key_2 => tracker_2
+      }
+
+      bind(MessageTracker, :get_message_tracker, fn _ -> {:ok, trackers[sharding_key_1]} end, calls: 1)
+
+      payload_1 = get_payload()
+      meta_1 = meta_fixture(sharding_key_1)
+
+      send(data_consumer_pid, {:basic_deliver, payload_1, meta_1})
+
+      assert_receive {:trace, ^tracker_1, :receive, {_, {_, message_1, _}}}
+      refute_receive {:trace, ^tracker_2, :receive, _}
+      assert message_1.payload == payload_1
+      assert sharding_key_from(message_1) == sharding_key_1
+
+      payload_2 = get_payload()
+      meta_2 = meta_fixture(sharding_key_2)
+
+      bind(MessageTracker, :get_message_tracker, fn _ -> {:ok, trackers[sharding_key_2]} end, calls: 1)
+
+      send(data_consumer_pid, {:basic_deliver, payload_2, meta_2})
+
+      assert_receive {:trace, ^tracker_2, :receive, {_, {_, message_2, _}}}
+      refute_receive {:trace, ^tracker_1, :receive, _}
+      assert message_2.payload == payload_2
+      assert sharding_key_from(message_2) == sharding_key_2
+    end
+
+    @tag :data_consumer_message_handling
+    test "AMQPDataConsumer monitors a MessageTracker when starting to forward messages", %{
+      queue_index: queue_index,
+      message_tracker: message_tracker,
+      payload: payload,
+      meta: meta
+    } do
+      data_consumer_pid =
+        start_supervised!(
+          {AMQPDataConsumer, [queue_index: queue_index, queue_name: "queue_#{queue_index}"]},
+          id: {AMQPDataConsumer, queue_index}
+        )
+
+      bind(MessageTracker, :get_message_tracker, fn _ -> {:ok, message_tracker} end, calls: 1)
+
+      send(data_consumer_pid, {:basic_deliver, payload, meta})
+
+      assert %State{monitors: [^message_tracker]} = :sys.get_state(data_consumer_pid)
+    end
+  end
+
+  describe "AMQPDataConsumer fault tolerance:" do
+    setup :create_queue_index
+    setup :create_sharding_key
+    setup :create_payload
+    setup :create_meta
+    setup :setup_mock_message_tracker
+    setup :setup_mox
+
+    @tag :data_consumer_fault_tolerance
+    test "a process stays up when a monitored MessageTracker exits normally", %{
+      queue_index: queue_index,
+      message_tracker: message_tracker,
+      payload: payload,
+      meta: meta
+    } do
+      data_consumer_pid =
+        start_supervised!(
+          {AMQPDataConsumer, [queue_index: queue_index, queue_name: "queue_#{queue_index}"]},
+          id: {AMQPDataConsumer, queue_index}
+        )
+
+      bind(MessageTracker, :get_message_tracker, fn _ -> {:ok, message_tracker} end, calls: 1)
+
+      send(data_consumer_pid, {:basic_deliver, payload, meta})
+
+      assert %State{monitors: [^message_tracker]} = :sys.get_state(data_consumer_pid)
+
+      kill_message_tracker(message_tracker)
+      :erlang.trace(data_consumer_pid, true, [:receive])
+
+      assert_receive {:trace, ^data_consumer_pid, :receive, {:DOWN, _, :process, ^message_tracker, :normal}}
+
+      assert Process.alive?(data_consumer_pid)
+
+      assert %State{monitors: []} = :sys.get_state(data_consumer_pid)
+    end
+
+    @tag :data_consumer_fault_tolerance
+    test "a process crashes if the related MessageTracker crashes", %{
+      queue_index: queue_index,
+      message_tracker: message_tracker,
+      payload: payload,
+      meta: meta
+    } do
+      Process.flag(:trap_exit, true)
+
+      {:ok, data_consumer_pid} =
+        GenServer.start(
+          AMQPDataConsumer,
+          [queue_index: queue_index, queue_name: "queue_#{queue_index}"],
+          id: {AMQPDataConsumer, queue_index}
+        )
+
+      consumer_ref = Process.monitor(data_consumer_pid)
+
+      bind(MessageTracker, :get_message_tracker, fn _ -> {:ok, message_tracker} end, calls: 1)
+
+      send(data_consumer_pid, {:basic_deliver, payload, meta})
+
+      assert %State{monitors: [^message_tracker]} = :sys.get_state(data_consumer_pid)
+
+      send(data_consumer_pid, {:DOWN, :dontcare, :process, message_tracker, :crash})
+
+      assert_receive {:DOWN, ^consumer_ref, :process, ^data_consumer_pid, _}
+
+      refute Process.alive?(data_consumer_pid)
+    end
+  end
+
+  defp sharding_key_from(message) do
+    :erlang.binary_to_term(message.headers["sharding_key"])
+  end
+
+  defp setup_mox(context) do
     mock_channel = %Channel{pid: self()}
 
     MockAMQPConnection
@@ -22,56 +179,32 @@ defmodule Mississippi.Consumer.AMQPDataConsumer.Test do
 
     Mox.set_mox_global()
 
-    :ok
+    context
   end
 
-  doctest Mississippi.Consumer.AMQPDataConsumer
+  defp create_queue_index(context) do
+    index = System.unique_integer([:positive])
 
-  setup do
-    process_1 = Process.spawn(&wait_for_message/0, [])
-    :erlang.trace(process_1, true, [:receive])
-
-    process_2 = Process.spawn(&wait_for_message/0, [])
-    :erlang.trace(process_2, true, [:receive])
-
-    %{
-      sharding_key_1: process_1,
-      sharding_key_2: process_2
-    }
+    Map.put(context, :queue_index, index)
   end
 
-  test "Messages are forwarded to different trackers based on sharding key", %{
-    sharding_key_1: tracker_1,
-    sharding_key_2: tracker_2
-  } do
-    data_consumer_pid =
-      start_supervised!({AMQPDataConsumer, queue_index: 0, queue_name: "queue_0"})
+  defp setup_mock_message_tracker(context) do
+    message_tracker = get_message_tracker()
+    Map.put(context, :message_tracker, message_tracker)
+  end
 
-    sharding_key_1 = :sharding_key_1
-    sharding_key_2 = :sharding_key_2
+  defp get_payload do
+    "payload_#{System.unique_integer()}"
+  end
 
-    bind(MessageTracker, :get_message_tracker, fn _ -> {:ok, tracker_1} end, calls: 1)
-    bind(MessageTracker, :get_message_tracker, fn _ -> {:ok, tracker_2} end, calls: 1)
+  defp create_payload(context) do
+    Map.put(context, :payload, get_payload())
+  end
 
-    payload_1 = "payload_#{System.unique_integer()}"
-    meta_1 = meta_fixture(sharding_key_1)
+  defp create_meta(context) do
+    %{sharding_key: sharding_key} = context
 
-    send(data_consumer_pid, {:basic_deliver, payload_1, meta_1})
-
-    assert_receive {:trace, ^tracker_1, :receive, {_, {_, message_1, _}}}
-    refute_receive {:trace, ^tracker_2, :receive, _}
-    assert message_1.payload == payload_1
-    assert sharding_key_from(message_1) == sharding_key_1
-
-    payload_2 = "payload_#{System.unique_integer()}"
-    meta_2 = meta_fixture(sharding_key_2)
-
-    send(data_consumer_pid, {:basic_deliver, payload_2, meta_2})
-
-    assert_receive {:trace, ^tracker_2, :receive, {_, {_, message_2, _}}}
-    refute_receive {:trace, ^tracker_1, :receive, _}
-    assert message_2.payload == payload_2
-    assert sharding_key_from(message_2) == sharding_key_2
+    Map.put(context, :meta, meta_fixture(sharding_key))
   end
 
   defp meta_fixture(sharding_key) do
@@ -83,13 +216,22 @@ defmodule Mississippi.Consumer.AMQPDataConsumer.Test do
     }
   end
 
-  defp wait_for_message do
-    receive do
-      x -> x
-    end
+  defp get_sharding_key do
+    "sharding_#{System.unique_integer()}"
   end
 
-  defp sharding_key_from(message) do
-    :erlang.binary_to_term(message.headers["sharding_key"])
+  defp create_sharding_key(context) do
+    Map.put(context, :sharding_key, get_sharding_key())
+  end
+
+  defp get_message_tracker do
+    {:ok, message_tracker} = GenServer.start(Placeholder, [])
+    :erlang.trace(message_tracker, true, [:receive])
+
+    message_tracker
+  end
+
+  def kill_message_tracker(message_tracker) do
+    GenServer.cast(message_tracker, :die)
   end
 end

--- a/test/consumer/data_updater_test.exs
+++ b/test/consumer/data_updater_test.exs
@@ -1,70 +1,203 @@
 defmodule Mississippi.Consumer.DataUpdater.Test do
-  use ExUnit.Case
+  use EfxCase, async: false
 
   import Hammox
 
   alias Mississippi.Consumer.DataUpdater
+  alias Mississippi.Consumer.DataUpdater.State
+  alias Mississippi.Consumer.MessageTracker
+  alias Mississippi.Consumer.Test.Placeholder
+
+  @moduletag :unit
 
   setup_all do
     start_supervised!({Registry, [keys: :unique, name: Registry.DataUpdater]})
 
     start_supervised!({DataUpdater.Supervisor, message_handler: MockMessageHandler})
 
-    stub(MockMessageHandler, :init, fn _key -> {:ok, []} end)
-
-    set_mox_global()
-
     :ok
   end
 
   doctest Mississippi.Consumer.DataUpdater
 
-  test "a DataUpdater process is successfully started with a given sharding key" do
-    sharding_key = "sharding_#{System.unique_integer()}"
-    {:ok, pid} = DataUpdater.get_data_updater_process(sharding_key)
+  describe "DataUpdater works as an Orleans grain:" do
+    setup :setup_mock_message_handler
+    setup :create_sharding_key
 
-    dup_processes = Registry.select(Registry.DataUpdater, [{{:"$1", :_, :_}, [], [:"$1"]}])
+    @tag :data_updater_orleans
+    test "a process is successfully started with a given sharding key", %{
+      sharding_key: sharding_key
+    } do
+      {:ok, pid} = DataUpdater.get_data_updater_process(sharding_key)
 
-    assert [{:sharding_key, ^sharding_key}] = dup_processes
+      du_processes =
+        Registry.select(Registry.DataUpdater, [{{:"$1", :"$2", :_}, [], [{{:"$1", :"$2"}}]}])
 
-    on_exit(fn -> DataUpdater.Supervisor.terminate_child(pid) end)
+      assert {{:sharding_key, sharding_key}, pid} in du_processes
+    end
+
+    @tag :data_updater_orleans
+    test "a process is not duplicated when using the same sharding key", %{
+      sharding_key: sharding_key
+    } do
+      {:ok, pid} = DataUpdater.get_data_updater_process(sharding_key)
+
+      du_processes =
+        Registry.select(Registry.DataUpdater, [{{:"$1", :"$2", :_}, [], [{{:"$1", :"$2"}}]}])
+
+      assert {{:sharding_key, sharding_key}, pid} in du_processes
+
+      {:ok, ^pid} = DataUpdater.get_data_updater_process(sharding_key)
+      assert {{:sharding_key, sharding_key}, pid} in du_processes
+    end
+
+    @tag :data_updater_orleans
+    test "a process is spawned again if requested after termination", %{
+      sharding_key: sharding_key
+    } do
+      {:ok, first_pid} = DataUpdater.get_data_updater_process(sharding_key)
+
+      du_processes =
+        Registry.select(Registry.DataUpdater, [{{:"$1", :"$2", :_}, [], [{{:"$1", :"$2"}}]}])
+
+      assert {{:sharding_key, sharding_key}, first_pid} in du_processes
+
+      DynamicSupervisor.terminate_child(DataUpdater.Supervisor, first_pid)
+
+      {:ok, second_pid} = DataUpdater.get_data_updater_process(sharding_key)
+      assert first_pid != second_pid
+
+      du_processes =
+        Registry.select(Registry.DataUpdater, [{{:"$1", :"$2", :_}, [], [{{:"$1", :"$2"}}]}])
+
+      assert {{:sharding_key, sharding_key}, second_pid} in du_processes
+      refute {{:sharding_key, sharding_key}, first_pid} in du_processes
+    end
   end
 
-  test "a DataUpdater process is not duplicated when using the same sharding key" do
-    sharding_key = "sharding_#{System.unique_integer()}"
-    {:ok, pid} = DataUpdater.get_data_updater_process(sharding_key)
+  describe "DataUpdater handles messages:" do
+    setup :setup_mock_message_handler
+    setup :create_sharding_key
+    setup :create_message
+    setup :setup_mock_message_tracker
+    setup :add_on_exit
 
-    dup_processes = Registry.select(Registry.DataUpdater, [{{:"$1", :_, :_}, [], [:"$1"]}])
-    assert [{:sharding_key, ^sharding_key}] = dup_processes
+    @tag :data_updater_message_handling
+    test "acking when ok", %{
+      sharding_key: sharding_key,
+      message: message,
+      message_tracker: message_tracker
+    } do
+      expect(MockMessageHandler, :handle_message, fn _, _, _, _, state -> {:ok, :ok, state} end)
 
-    {:ok, ^pid} = DataUpdater.get_data_updater_process(sharding_key)
-    assert [{:sharding_key, ^sharding_key}] = dup_processes
+      {:ok, data_updater_pid} = DataUpdater.get_data_updater_process(sharding_key)
 
-    on_exit(fn -> DataUpdater.Supervisor.terminate_child(pid) end)
+      :erlang.trace(data_updater_pid, true, [:receive])
+
+      bind(MessageTracker, :get_message_tracker, fn _ -> {:ok, message_tracker} end, calls: 1)
+
+      DataUpdater.handle_message(data_updater_pid, message)
+
+      assert_receive {:trace, ^message_tracker, :receive, {_, {_, _}, {:ack_delivery, ^message}}}
+    end
+
+    @tag :data_updater_message_handling
+    test "rejecting when error", %{
+      sharding_key: sharding_key,
+      message: message,
+      message_tracker: message_tracker
+    } do
+      expect(MockMessageHandler, :handle_message, fn _, _, _, _, state ->
+        {:error, :aaaa, state}
+      end)
+
+      {:ok, data_updater_pid} = DataUpdater.get_data_updater_process(sharding_key)
+
+      :erlang.trace(data_updater_pid, true, [:receive])
+
+      bind(MessageTracker, :get_message_tracker, fn _ -> {:ok, message_tracker} end, calls: 1)
+
+      DataUpdater.handle_message(data_updater_pid, message)
+
+      assert_receive {:trace, ^message_tracker, :receive, {_, {_, _}, {:reject, ^message}}}
+    end
   end
 
-  test "a DataUpdater process is spawned again if requested after termination" do
-    sharding_key = "sharding_#{System.unique_integer()}"
-    {:ok, first_pid} = DataUpdater.get_data_updater_process(sharding_key)
+  describe "DataUpdater handles signals:" do
+    setup :setup_mock_message_handler
+    setup :create_sharding_key
+    setup :create_signal
 
-    du_process =
-      Registry.select(Registry.DataUpdater, [{{:"$1", :"$2", :_}, [], [{{:"$1", :"$2"}}]}])
+    @tag :data_updater_signal_handling
+    test "updating the handler state", %{
+      sharding_key: sharding_key,
+      signal: signal
+    } do
+      expect(MockMessageHandler, :init, fn _sharding_key ->
+        {:ok, %{signals: []}}
+      end)
 
-    assert [{{:sharding_key, ^sharding_key}, ^first_pid}] = du_process
+      expect(MockMessageHandler, :handle_signal, fn signal, _state ->
+        {:ok, %{signals: [signal]}}
+      end)
 
-    DynamicSupervisor.terminate_child(DataUpdater.Supervisor, first_pid)
-    # Give some time to the Registry to delete the entry
-    Process.sleep(:timer.seconds(2))
-    [] = Registry.select(Registry.DataUpdater, [{{:"$1", :_, :_}, [], [:"$1"]}])
+      {:ok, data_updater_pid} = DataUpdater.get_data_updater_process(sharding_key)
 
-    {:ok, second_pid} = DataUpdater.get_data_updater_process(sharding_key)
-    assert first_pid != second_pid
+      assert %State{handler_state: %{signals: []}} = :sys.get_state(data_updater_pid)
 
-    du_process =
-      Registry.select(Registry.DataUpdater, [{{:"$1", :"$2", :_}, [], [{{:"$1", :"$2"}}]}])
+      DataUpdater.handle_signal(data_updater_pid, signal)
 
-    assert [{{:sharding_key, ^sharding_key}, ^second_pid}] = du_process
+      assert %State{handler_state: %{signals: [^signal]}} = :sys.get_state(data_updater_pid)
+    end
+  end
 
-    on_exit(fn -> DynamicSupervisor.terminate_child(DataUpdater.Supervisor, second_pid) end)
+  defp setup_mock_message_handler(_context) do
+    stub(MockMessageHandler, :init, fn _key -> {:ok, []} end)
+
+    Hammox.set_mox_global()
+  end
+
+  defp create_sharding_key(context) do
+    Map.put(context, :sharding_key, "sharding_#{System.unique_integer()}")
+  end
+
+  defp create_message(context) do
+    %{sharding_key: sharding_key} = context
+    message = message_fixture(sharding_key)
+
+    Map.put(context, :message, message)
+  end
+
+  defp create_signal(context) do
+    signal = System.unique_integer([])
+
+    Map.put(context, :signal, signal)
+  end
+
+  defp add_on_exit(context) do
+    if context[:message_tracker] do
+      on_exit(fn -> Process.exit(context.message_tracker, :kill) end)
+    end
+
+    context
+  end
+
+  defp setup_mock_message_tracker(context) do
+    {:ok, message_tracker} = GenServer.start(Placeholder, [])
+
+    :erlang.trace(message_tracker, true, [:receive])
+    Map.put(context, :message_tracker, message_tracker)
+  end
+
+  defp message_fixture(sharding_key) do
+    %Mississippi.Consumer.Message{
+      payload: "payload_#{System.unique_integer()}",
+      headers: %{"sharding_key" => :erlang.term_to_binary(sharding_key)},
+      timestamp: DateTime.utc_now(),
+      meta: %{
+        message_id: "#{System.unique_integer()}",
+        delivery_tag: System.unique_integer()
+      }
+    }
   end
 end

--- a/test/consumer/message_tracker_test.exs
+++ b/test/consumer/message_tracker_test.exs
@@ -1,66 +1,289 @@
 defmodule Mississippi.Consumer.MessageTracker.Test do
-  use ExUnit.Case
+  use EfxCase, async: false
 
+  import Hammox
+
+  alias AMQP.Channel
+  alias Mississippi.Consumer.DataUpdater
   alias Mississippi.Consumer.MessageTracker
+  alias Mississippi.Consumer.MessageTracker.Server.State
+  alias Mississippi.Consumer.Test.Placeholder
 
   require Logger
 
-  setup_all do
-    start_supervised!({Registry, [keys: :unique, name: Registry.MessageTracker]})
+  @moduletag :unit
 
-    start_supervised!({DynamicSupervisor, strategy: :one_for_one, name: MessageTracker.Supervisor})
+  setup_all do
+    start_supervised({Registry, [keys: :unique, name: Registry.MessageTracker]})
+
+    start_supervised({DynamicSupervisor, strategy: :one_for_one, name: MessageTracker.Supervisor})
 
     :ok
   end
 
   doctest Mississippi.Consumer.MessageTracker
 
-  test "a MessageTracker process is successfully started with a given sharding key" do
-    sharding_key = "sharding_#{System.unique_integer()}"
-    {:ok, pid} = MessageTracker.get_message_tracker(sharding_key)
+  describe "MessageTracker works as an Orleans grain:" do
+    setup :create_sharding_key
 
-    mt_processes = Registry.select(Registry.MessageTracker, [{{:"$1", :_, :_}, [], [:"$1"]}])
+    @tag :message_tracker_orleans
+    test "a process is successfully started with a given sharding key", %{
+      sharding_key: sharding_key
+    } do
+      {:ok, pid} = MessageTracker.get_message_tracker(sharding_key)
 
-    assert [{:sharding_key, ^sharding_key}] = mt_processes
+      mt_processes =
+        Registry.select(Registry.MessageTracker, [{{:"$1", :"$2", :_}, [], [{{:"$1", :"$2"}}]}])
 
-    on_exit(fn -> DynamicSupervisor.terminate_child(MessageTracker.Supervisor, pid) end)
+      assert {{:sharding_key, sharding_key}, pid} in mt_processes
+    end
+
+    @tag :message_tracker_orleans
+    test "a process is not duplicated when using the same sharding key", %{
+      sharding_key: sharding_key
+    } do
+      {:ok, pid} = MessageTracker.get_message_tracker(sharding_key)
+
+      mt_processes =
+        Registry.select(Registry.MessageTracker, [{{:"$1", :"$2", :_}, [], [{{:"$1", :"$2"}}]}])
+
+      assert {{:sharding_key, sharding_key}, pid} in mt_processes
+
+      {:ok, ^pid} = MessageTracker.get_message_tracker(sharding_key)
+      assert {{:sharding_key, sharding_key}, pid} in mt_processes
+    end
+
+    @tag :message_tracker_orleans
+    test "a process is spawned again if requested after termination", %{
+      sharding_key: sharding_key
+    } do
+      {:ok, first_pid} = MessageTracker.get_message_tracker(sharding_key)
+
+      mt_processes =
+        Registry.select(Registry.MessageTracker, [{{:"$1", :"$2", :_}, [], [{{:"$1", :"$2"}}]}])
+
+      assert {{:sharding_key, sharding_key}, first_pid} in mt_processes
+
+      DynamicSupervisor.terminate_child(MessageTracker.Supervisor, first_pid)
+
+      {:ok, second_pid} = MessageTracker.get_message_tracker(sharding_key)
+      assert first_pid != second_pid
+
+      mt_processes =
+        Registry.select(Registry.MessageTracker, [{{:"$1", :"$2", :_}, [], [{{:"$1", :"$2"}}]}])
+
+      assert {{:sharding_key, sharding_key}, second_pid} in mt_processes
+      refute {{:sharding_key, sharding_key}, first_pid} in mt_processes
+    end
   end
 
-  test "a MessageTracker process is not duplicated when using the same sharding key" do
-    sharding_key = "sharding_#{System.unique_integer()}"
-    {:ok, pid} = MessageTracker.get_message_tracker(sharding_key)
+  describe "MessageTracker fault tolerance:" do
+    setup :setup_mock_message_handler
+    setup :create_sharding_key
+    setup :create_message
+    setup :setup_mock_channel
+    setup :setup_mock_data_updater
+    setup :add_on_exit
 
-    mt_processes = Registry.select(Registry.MessageTracker, [{{:"$1", :_, :_}, [], [:"$1"]}])
-    assert [{:sharding_key, ^sharding_key}] = mt_processes
+    @tag :message_tracker_fault_tolerance
+    test "a process crashes if the related AMQP Channel crashes", %{
+      sharding_key: sharding_key,
+      channel: channel,
+      data_updater: data_updater,
+      message: message
+    } do
+      {:ok, message_tracker_pid} = MessageTracker.get_message_tracker(sharding_key)
+      mt_ref = Process.monitor(message_tracker_pid)
 
-    {:ok, ^pid} = MessageTracker.get_message_tracker(sharding_key)
-    assert [{:sharding_key, ^sharding_key}] = mt_processes
+      MessageTracker.handle_message(message_tracker_pid, message, channel)
 
-    on_exit(fn -> DynamicSupervisor.terminate_child(MessageTracker.Supervisor, pid) end)
+      bind(DataUpdater, :get_data_updater_process, fn _ -> {:ok, data_updater} end)
+
+      send(message_tracker_pid, {:DOWN, :dontcare, :process, channel.pid, :crash})
+
+      assert_receive {:DOWN, ^mt_ref, :process, ^message_tracker_pid, :channel_crashed}
+
+      refute Process.alive?(message_tracker_pid)
+    end
+
+    @tag :message_tracker_fault_tolerance
+    test "a process resends the message if the related DataUpdater crashes", %{
+      sharding_key: sharding_key,
+      channel: channel,
+      message: message
+    } do
+      {:ok, message_tracker_pid} = MessageTracker.get_message_tracker(sharding_key)
+      :erlang.trace(message_tracker_pid, true, [:receive])
+
+      data_updater_1_pid = get_mock_data_updater!()
+
+      bind(DataUpdater, :get_data_updater_process, fn _ -> {:ok, data_updater_1_pid} end, calls: 1)
+
+      MessageTracker.handle_message(message_tracker_pid, message, channel)
+
+      assert_receive {:trace, ^data_updater_1_pid, :receive, {_, {:handle_message, ^message}}}
+
+      kill_data_updater(data_updater_1_pid)
+
+      assert_receive {:trace, ^message_tracker_pid, :receive, {:DOWN, _, :process, ^data_updater_1_pid, :normal}}
+
+      data_updater_2_pid = get_mock_data_updater!()
+
+      bind(DataUpdater, :get_data_updater_process, fn _ -> {:ok, data_updater_2_pid} end, calls: 1)
+
+      assert_receive {:trace, ^data_updater_2_pid, :receive, {_, {:handle_message, ^message}}}
+    end
   end
 
-  test "a MessageTracker process is spawned again if requested after termination" do
-    sharding_key = "sharding_#{System.unique_integer()}"
-    {:ok, first_pid} = MessageTracker.get_message_tracker(sharding_key)
+  describe "MessageTracker message handling:" do
+    setup :setup_mock_message_handler
+    setup :create_sharding_key
+    setup :create_message
+    setup :setup_mock_channel
+    setup :add_on_exit
 
-    mt_processes =
-      Registry.select(Registry.MessageTracker, [{{:"$1", :"$2", :_}, [], [{{:"$1", :"$2"}}]}])
+    @tag :message_tracker_message_handling
+    test "is successful on valid message", %{
+      sharding_key: sharding_key,
+      channel: channel,
+      message: message
+    } do
+      {:ok, message_tracker_pid} = MessageTracker.get_message_tracker(sharding_key)
+      :erlang.trace(message_tracker_pid, true, [:receive])
 
-    assert [{{:sharding_key, ^sharding_key}, ^first_pid}] = mt_processes
+      {:ok, data_updater_pid} =
+        GenServer.start_link(DataUpdater,
+          sharding_key: sharding_key,
+          message_handler: MockMessageHandler
+        )
 
-    DynamicSupervisor.terminate_child(MessageTracker.Supervisor, first_pid)
-    # Give some time to the Registry to delete the entry
-    Process.sleep(:timer.seconds(2))
-    [] = Registry.select(Registry.MessageTracker, [{{:"$1", :_, :_}, [], [:"$1"]}])
+      :erlang.trace(data_updater_pid, true, [:receive])
 
-    {:ok, second_pid} = MessageTracker.get_message_tracker(sharding_key)
-    assert first_pid != second_pid
+      bind(DataUpdater, :get_data_updater_process, fn _ -> {:ok, data_updater_pid} end, calls: 1)
 
-    mt_processes =
-      Registry.select(Registry.MessageTracker, [{{:"$1", :"$2", :_}, [], [{{:"$1", :"$2"}}]}])
+      MessageTracker.handle_message(message_tracker_pid, message, channel)
 
-    assert [{{:sharding_key, ^sharding_key}, ^second_pid}] = mt_processes
+      assert_receive {:trace, ^data_updater_pid, :receive, {_, {:handle_message, ^message}}}
 
-    on_exit(fn -> DynamicSupervisor.terminate_child(MessageTracker.Supervisor, second_pid) end)
+      bind(MessageTracker, :get_message_tracker, fn _ -> {:ok, message_tracker_pid} end, calls: 1)
+
+      assert_receive {:trace, ^message_tracker_pid, :receive, {_, {_, _}, {:ack_delivery, ^message}}}
+    end
+
+    @tag :message_tracker_message_handling
+    test "respects ordering of messages", %{
+      sharding_key: sharding_key,
+      channel: channel
+    } do
+      message_1 = message_fixture(sharding_key)
+      message_2 = message_fixture(sharding_key)
+      {:ok, message_tracker_pid} = MessageTracker.get_message_tracker(sharding_key)
+      :erlang.trace(message_tracker_pid, true, [:receive])
+      bind(MessageTracker, :get_message_tracker, fn _ -> {:ok, message_tracker_pid} end)
+
+      {:ok, data_updater_pid} =
+        GenServer.start_link(DataUpdater,
+          sharding_key: sharding_key,
+          message_handler: MockMessageHandler
+        )
+
+      :erlang.trace(data_updater_pid, true, [:receive])
+      bind(DataUpdater, :get_data_updater_process, fn _ -> {:ok, data_updater_pid} end)
+
+      MessageTracker.handle_message(message_tracker_pid, message_1, channel)
+      MessageTracker.handle_message(message_tracker_pid, message_2, channel)
+      message_queue = :queue.from_list([message_1, message_2])
+
+      assert %State{queue: ^message_queue} = :sys.get_state(message_tracker_pid)
+
+      assert_receive {:trace, ^data_updater_pid, :receive, {_, {:handle_message, ^message_1}}}
+
+      refute_received {:trace, ^data_updater_pid, :receive, {_, {:handle_message, ^message_2}}}
+
+      assert_receive {:trace, ^message_tracker_pid, :receive,
+                      {:"$gen_call", {^data_updater_pid, _}, {:ack_delivery, ^message_1}}}
+
+      refute_received {:trace, ^message_tracker_pid, :receive,
+                       {:"$gen_call", {^data_updater_pid, _}, {:ack_delivery, ^message_2}}}
+
+      # According to :queue, :queue.drop(:queue.from_list([message_1, message_2])) != :queue.from_list([message_2])
+      queue_2 = :queue.drop(message_queue)
+
+      assert %State{queue: ^queue_2} = :sys.get_state(message_tracker_pid)
+
+      assert_receive {:trace, ^data_updater_pid, :receive, {_, {:handle_message, ^message_2}}}
+
+      assert_receive {:trace, ^message_tracker_pid, :receive,
+                      {:"$gen_call", {^data_updater_pid, _}, {:ack_delivery, ^message_2}}}
+    end
+  end
+
+  defp setup_mock_message_handler(_context) do
+    MockMessageHandler
+    |> stub(:init, fn _ -> {:ok, []} end)
+    |> stub(:handle_message, fn _, _, _, _, _ -> {:ok, :ok, []} end)
+
+    Hammox.set_mox_global()
+  end
+
+  defp create_sharding_key(context) do
+    Map.put(context, :sharding_key, "sharding_#{System.unique_integer()}")
+  end
+
+  defp create_message(context) do
+    %{sharding_key: sharding_key} = context
+    message = message_fixture(sharding_key)
+
+    Map.put(context, :message, message)
+  end
+
+  defp add_on_exit(context) do
+    if context[:channel] do
+      on_exit(fn -> Process.exit(context.channel.pid, :kill) end)
+    end
+
+    if context[:data_updater] do
+      on_exit(fn -> Process.exit(context.data_updater, :kill) end)
+    end
+
+    context
+  end
+
+  defp setup_mock_channel(context) do
+    {:ok, pid} = GenServer.start(Placeholder, [])
+
+    channel = %Channel{pid: pid}
+
+    Map.put(context, :channel, channel)
+  end
+
+  defp setup_mock_data_updater(context) do
+    data_updater = get_mock_data_updater!()
+
+    Map.put(context, :data_updater, data_updater)
+  end
+
+  defp get_mock_data_updater! do
+    {:ok, data_updater} = GenServer.start(Placeholder, [])
+
+    :erlang.trace(data_updater, true, [:receive])
+
+    data_updater
+  end
+
+  defp kill_data_updater(data_updater) do
+    GenServer.cast(data_updater, :die)
+  end
+
+  defp message_fixture(sharding_key) do
+    %Mississippi.Consumer.Message{
+      payload: "payload_#{System.unique_integer()}",
+      headers: %{"sharding_key" => :erlang.term_to_binary(sharding_key)},
+      timestamp: DateTime.utc_now(),
+      meta: %{
+        message_id: "#{System.unique_integer()}",
+        delivery_tag: System.unique_integer()
+      }
+    }
   end
 end

--- a/test/support/placeholder.ex
+++ b/test/support/placeholder.ex
@@ -1,0 +1,24 @@
+defmodule Mississippi.Consumer.Test.Placeholder do
+  @moduledoc false
+  use GenServer
+
+  @impl true
+  def init(init_arg) do
+    {:ok, init_arg}
+  end
+
+  @impl true
+  def handle_call(_request, _from, state) do
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_cast(:die, state) do
+    {:stop, :normal, state}
+  end
+
+  @impl true
+  def handle_cast(_, state) do
+    {:noreply, state}
+  end
+end


### PR DESCRIPTION
Test non-trivial properties of the current consumer implementation.
This provides an higher level of safety for the application, at the cost of testing some implementation details (e.g. a process is able to handle some form of failure coming from a monitored process).
Add specific test tags to allow finer-grained testing should implementation change in the future.

Based on #9.