### PR TITLE
Consumer: refine the `Handler` behaviour on received messages

### DIFF
--- a/lib/consumer/data_updater/impl.ex
+++ b/lib/consumer/data_updater/impl.ex
@@ -14,13 +14,19 @@ defmodule Mississippi.Consumer.DataUpdater.Handler.Impl do
       "Received message #{inspect(message_id)} with payload #{inspect(payload)} and headers #{inspect(headers)} at #{inspect(DateTime.from_unix!(timestamp))}"
     )
 
-    {:ok, :ok, state}
+    {:ack, :ok, state}
   end
 
   @impl true
   def handle_signal(signal, state) do
     IO.puts("Received signal #{inspect(signal)}")
 
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_continue(continue_arg, state) do
+    IO.puts("Received continue with arg #{inspect(continue_arg)}")
     {:ok, state}
   end
 

--- a/lib/consumer/message_tracker/server.ex
+++ b/lib/consumer/message_tracker/server.ex
@@ -98,6 +98,15 @@ defmodule Mississippi.Consumer.MessageTracker.Server do
   end
 
   @impl true
+  def handle_info(
+        {:DOWN, _ref, :process, down_pid, {:shutdown, :requested}},
+        %State{data_updater_pid: data_updater_pid} = state
+      )
+      when down_pid == data_updater_pid do
+    {:stop, {:shutdown, :requested}, state}
+  end
+
+  @impl true
   def handle_info({:DOWN, _ref, :process, down_pid, _reason}, state) do
     %State{data_updater_pid: data_updater_pid} = state
 

--- a/test/support/e2e_message_handler.ex
+++ b/test/support/e2e_message_handler.ex
@@ -24,6 +24,11 @@ defmodule E2EMessageHandler do
   end
 
   @impl Handler
+  def handle_continue(_continue_arg, state) do
+    {:ok, state}
+  end
+
+  @impl Handler
   def terminate(_reason, _state) do
     :ok
   end


### PR DESCRIPTION
Allow more flexibility when handling messages. The `handle_message/5` callback now returns _threeither_ `:ack` (formerly `:ok`), `:discard` (formerly `:error`) or `:stop`.
This way, a user can also request termination of a DataUpdater/MessageTracker process pair after having handled a message.

Allow also a DataUpdater process to perform operations after a message has been acked/discarded by introducing the `handle_continue/2` callback, which works pretty much like a GenServer's.