### PR TITLE
Fix `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2024-09-04
+## [1.0.0] - Unreleased
 ### Added
 - First Mississippi release.


### PR DESCRIPTION
The release process will require clerical work on dependencies, not strictly related to the actual code.
Update the changelog to reflect this. It will be changed for good once the last dependency is moved from Github to hex.pm.