### PR TITLE
Consumer: avoid duplicate processes in distributed setting

### DIFF
--- a/lib/consumer/data_updater.ex
+++ b/lib/consumer/data_updater.ex
@@ -10,7 +10,8 @@ defmodule Mississippi.Consumer.DataUpdater do
   MessageTracker process that takes care of maitaining the order of messages.
   """
 
-  use GenServer, restart: :transient
+  # We'll be made alive on demand
+  use GenServer, restart: :temporary
   use Efx
 
   alias Horde.Registry

--- a/lib/consumer/message_tracker/server.ex
+++ b/lib/consumer/message_tracker/server.ex
@@ -6,7 +6,8 @@ defmodule Mississippi.Consumer.MessageTracker.Server do
   This module implements the MessageTracker process logic.
   """
 
-  use GenServer, restart: :transient
+  # We'll be made alive on demand
+  use GenServer, restart: :temporary
 
   alias Mississippi.Consumer.DataUpdater
   alias Mississippi.Consumer.Message


### PR DESCRIPTION
When using Horde in a distributed cluster, it might happen that two processes for the same registry value are spawned. While Horde takes care of shutting down the "wrong" one, we have to take care that it is not restarted by the supervisor. See https://hexdocs.pm/horde/eventual_consistency.html#horde-registry-merge-conflict.

So:
- Make the AMQPConsumerSupervisor exit with `:normal` when duplicated, that way it won't be restarted
- Make DataUpdater and MessageTraker processes temporary so that they will be restarted only when requested.