### PR TITLE
test: rework tests to address flakyness

### DIFF
--- a/test/consumer/amqp_data_consumer_test.exs
+++ b/test/consumer/amqp_data_consumer_test.exs
@@ -119,6 +119,8 @@ defmodule Mississippi.Consumer.AMQPDataConsumer.Test do
         |> amqp_data_consumer_fixture()
         |> start_supervised!()
 
+      :erlang.trace(data_consumer_pid, true, [:receive])
+
       bind(MessageTracker, :get_message_tracker, fn _ -> {:ok, message_tracker} end, calls: 1)
 
       send(data_consumer_pid, {:basic_deliver, payload, meta})
@@ -126,7 +128,6 @@ defmodule Mississippi.Consumer.AMQPDataConsumer.Test do
       assert %State{monitors: [^message_tracker]} = :sys.get_state(data_consumer_pid)
 
       kill_message_tracker(message_tracker)
-      :erlang.trace(data_consumer_pid, true, [:receive])
 
       assert_receive {:trace, ^data_consumer_pid, :receive, {:DOWN, _, :process, ^message_tracker, :normal}}
 


### PR DESCRIPTION
Mostly consists of placing commands in order to make sure the state is consistent with what we want, even if the processes take longer or shorter to execute.

`Registry.select` has been changed to an `assert_receive` equivalent to avoid timing issues

One test has been rewritten to address what is was meant to address, and not that messages take longer than 100ms to be processed

Depends on #24