### PR TITLE
Publish to default public hexpm org

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,6 @@ defmodule Mississippi.MixProject do
 
   defp package do
     [
-      organization: "",
       licenses: ["Apache-2.0"],
       links: %{"GitHub" => @source_url},
       maintainers: ["Arnaldo Cesco", "Francesco Noacco"]


### PR DESCRIPTION
Remove the `organization` field from `package` in `mix.exs` so that the default public org is used.